### PR TITLE
fix whatsapp -> discord copy-paste errors

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -166,7 +166,7 @@ var cmdLogout = &commands.FullHandler{
 	Name: "logout",
 	Help: commands.HelpMeta{
 		Section:     commands.HelpSectionAuth,
-		Description: "Unlink the bridge from your WhatsApp account.",
+		Description: "Unlink the bridge from your Discord account.",
 	},
 	RequiresLogin: true,
 }

--- a/main.go
+++ b/main.go
@@ -169,7 +169,7 @@ func main() {
 		Version:      "0.1.0",
 		ProtocolName: "Discord",
 
-		CryptoPickleKey: "maunium.net/go/mautrix-whatsapp",
+		CryptoPickleKey: "maunium.net/go/mautrix-discord",
 
 		ConfigUpgrader: &configupgrade.StructUpgrader{
 			SimpleUpgrader: configupgrade.SimpleUpgrader(config.DoUpgrade),


### PR DESCRIPTION
Closes https://github.com/mautrix/discord/issues/4

Not sure if renaming the pickle key is very compatible, but it's probably best to do sooner rather than later.