### PR TITLE
Fix inline code bridging from matrix to discord

### DIFF
--- a/formatter.go
+++ b/formatter.go
@@ -107,6 +107,8 @@ var discordMarkdownEscaper = strings.NewReplacer(
 	`<`, `\<`,
 )
 
+var discordMarkdownUnscaper = regexp.MustCompile(`\\(.)`);
+
 func escapeDiscordMarkdown(s string) string {
 	submatches := discordLinkRegex.FindAllStringIndex(s, -1)
 	if submatches == nil {
@@ -134,6 +136,18 @@ var matrixHTMLParser = &format.HTMLParser{
 	},
 	UnderlineConverter: func(s string, context format.Context) string {
 		return fmt.Sprintf("__%s__", s)
+	},
+	MonospaceConverter: func(s string, context format.Context) string {
+		s = discordMarkdownUnscaper.ReplaceAllString(s, "$1")
+		pre := ""
+		suf := ""
+		if (strings.HasPrefix(s, "`")) {
+			pre = " "
+		}
+		if (strings.HasSuffix(s, "`")) {
+			suf = " "
+		}
+		return fmt.Sprintf("``%s%s%s``", pre, s, suf)
 	},
 	TextConverter: func(s string, context format.Context) string {
 		return escapeDiscordMarkdown(s)


### PR DESCRIPTION
Previously, text inside inline code blocks got escaped unnecessarily, showing up as surplus backslashes on discord. This (mostly) fixes this, but it still breaks when the code block contains consecutive backticks. I'm not sure if there's a fix for that, except for the case when it only contains groups of 2 backticks, in which case sending `foo``bar` would work but this special case is not handled at the moment. (code blocks that only contain lone backticks do get sent properly)

Related: #37