### PR TITLE
Fix "video" embeds with missing video URLs

### DIFF
--- a/portal_convert.go
+++ b/portal_convert.go
@@ -204,12 +204,12 @@ func (portal *Portal) convertDiscordVideoEmbed(ctx context.Context, intent *apps
 	} else if embed.Thumbnail != nil {
 		proxyURL = embed.Thumbnail.ProxyURL
 	} else {
-		zerolog.Ctx(ctx).Error().Str("embed_url", embed.URL).Msg("failed to bridge media")
+		zerolog.Ctx(ctx).Warn().Str("embed_url", embed.URL).Msg("No video or thumbnail proxy URL found in embed")
 		return &ConvertedMessage{
 			AttachmentID: attachmentID,
 			Type:         event.EventMessage,
 			Content: &event.MessageEventContent{
-				Body:    "failed to bridge media",
+				Body:    "Failed to bridge media: no video or thumbnail proxy URL found in embed",
 				MsgType: event.MsgNotice,
 			},
 		}

--- a/portal_convert.go
+++ b/portal_convert.go
@@ -201,8 +201,18 @@ func (portal *Portal) convertDiscordVideoEmbed(ctx context.Context, intent *apps
 	var proxyURL string
 	if embed.Video != nil {
 		proxyURL = embed.Video.ProxyURL
-	} else {
+	} else if embed.Thumbnail != nil {
 		proxyURL = embed.Thumbnail.ProxyURL
+	} else {
+		zerolog.Ctx(ctx).Error().Str("embed_url", embed.URL).Msg("failed to bridge media")
+		return &ConvertedMessage{
+			AttachmentID: attachmentID,
+			Type:         event.EventMessage,
+			Content: &event.MessageEventContent{
+				Body:    "failed to bridge media",
+				MsgType: event.MsgNotice,
+			},
+		}
 	}
 	dbFile, err := portal.bridge.copyAttachmentToMatrix(intent, proxyURL, portal.Encrypted, NoMeta)
 	if err != nil {


### PR DESCRIPTION
I ran into an (old) message with a video embed from an unreachable website while backfilling on a large server with a few messages from 6 years ago.
The bridge crashed when reaching the message.