### PR TITLE
Bridge discord messages sent with @silent as m.notice

### DIFF
--- a/portal_convert.go
+++ b/portal_convert.go
@@ -723,6 +723,11 @@ func (portal *Portal) convertDiscordTextMessage(ctx context.Context, intent *app
 		"com.beeper.linkpreviews": previews,
 	}
 
+	if msg.Flags&discordgo.MessageFlagsSuppressNotifications != 0 {
+		// Send messages sent with @silent as m.notice
+		content.MsgType = event.MsgNotice
+	}
+
 	if msg.WebhookID != "" && msg.ApplicationID == "" && portal.bridge.Config.Bridge.PrefixWebhookMessages {
 		content.EnsureHasHTML()
 		content.Body = fmt.Sprintf("%s: %s", msg.Author.Username, content.Body)


### PR DESCRIPTION
Bridges discord messages marked as `@silent` as matrix notices.

Notice the bell icon in the corner
![imagen](https://github.com/user-attachments/assets/4ad7f18a-9f66-4357-a033-9bc8614829a1)
![imagen](https://github.com/user-attachments/assets/40b86d36-5716-4e01-90d2-fb157df7b7c5)
