### PR TITLE
Fix per-message profiles for members with custom guild avatars

### DIFF
--- a/portal_convert.go
+++ b/portal_convert.go
@@ -342,10 +342,10 @@ func (puppet *Puppet) addMemberMeta(part *ConvertedMessage, msg *discordgo.Messa
 	var discordAvatarURL string
 	if msg.Member.Avatar != "" {
 		var err error
-		avatarURL, discordAvatarURL, err = puppet.bridge.reuploadUserAvatar(puppet.DefaultIntent(), msg.GuildID, msg.Author.ID, msg.Author.Avatar)
+		avatarURL, discordAvatarURL, err = puppet.bridge.reuploadUserAvatar(puppet.DefaultIntent(), msg.GuildID, msg.Author.ID, msg.Member.Avatar)
 		if err != nil {
 			puppet.log.Warn().Err(err).
-				Str("avatar_id", msg.Author.Avatar).
+				Str("avatar_id", msg.Member.Avatar).
 				Msg("Failed to reupload guild user avatar")
 		}
 	}


### PR DESCRIPTION
Currently, mautrix-discord creates the avatar URL in the per-message profile using the guild ID and *Author* avatar hash. This results in an invalid avatar URL (like, it 404s) being created if the member has a custom guild avatar (which is possible with Discord Nitro). The solution here is to use the *Member* avatar hash instead.

There's some similar code below for webhooks but webhooks don't seem to suffer from this bug so I didn't change that.
