### PR TITLE
Fix typo in audio extension key name

### DIFF
--- a/portal_convert.go
+++ b/portal_convert.go
@@ -165,7 +165,7 @@ func (portal *Portal) convertDiscordAttachment(ctx context.Context, intent *apps
 		if att.Waveform != nil {
 			// TODO convert waveform
 			extra = map[string]any{
-				"org.matrix.1767.audio": map[string]any{
+				"org.matrix.msc1767.audio": map[string]any{
 					"duration": int(att.DurationSeconds * 1000),
 				},
 				"org.matrix.msc3245.voice": map[string]any{},


### PR DESCRIPTION
This causes the audio duration to not be shown in the element apps for example.