### PR TITLE
Update alpine to 3.21

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM dock.mau.dev/tulir/lottieconverter:alpine-3.18 AS lottie
+FROM dock.mau.dev/tulir/lottieconverter:alpine-3.21 AS lottie
 
-FROM golang:1-alpine3.18 AS builder
+FROM golang:1-alpine3.21 AS builder
 
 RUN apk add --no-cache git ca-certificates build-base su-exec olm-dev
 
@@ -8,7 +8,7 @@ COPY . /build
 WORKDIR /build
 RUN go build -o /usr/bin/mautrix-discord
 
-FROM alpine:3.18
+FROM alpine:3.21
 
 ENV UID=1337 \
     GID=1337

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,6 +1,6 @@
-FROM dock.mau.dev/tulir/lottieconverter:alpine-3.18 AS lottie
+FROM dock.mau.dev/tulir/lottieconverter:alpine-3.21 AS lottie
 
-FROM alpine:3.18
+FROM alpine:3.21
 
 ENV UID=1337 \
     GID=1337

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,6 +1,6 @@
-FROM dock.mau.dev/tulir/lottieconverter:alpine-3.18 AS lottie
+FROM dock.mau.dev/tulir/lottieconverter:alpine-3.21 AS lottie
 
-FROM golang:1-alpine3.18 AS builder
+FROM golang:1-alpine3.21 AS builder
 
 RUN apk add --no-cache git ca-certificates build-base su-exec olm-dev bash jq yq curl \
     zlib libpng giflib libstdc++ libgcc


### PR DESCRIPTION
This PR updates alpine in the Dockerfile from 3.18 to 3.21.

This is required as the [newest golang tag with alpine 3.18 is go 1.22](https://hub.docker.com/_/golang/tags?name=-alpine3.18) but the `go.mod` requires go 1.23 and therefore building the docker image fails.