### PR TITLE
Add support for media spoilers (bi-directional)

### DIFF
--- a/portal.go
+++ b/portal.go
@@ -1639,6 +1639,10 @@ func (portal *Portal) handleMatrixMessage(sender *User, evt *event.Event) {
 			sendReq.Content, sendReq.AllowedMentions = portal.parseMatrixHTML(content)
 		}
 
+		if content.EveryPizzaSpoiler {
+			filename = "SPOILER_" + filename
+		}
+
 		if portal.bridge.Config.Bridge.UseDiscordCDNUpload && !isWebhookSend && sess.IsUser {
 			att := &discordgo.MessageAttachment{
 				ID:          "0",

--- a/portal.go
+++ b/portal.go
@@ -1639,7 +1639,7 @@ func (portal *Portal) handleMatrixMessage(sender *User, evt *event.Event) {
 			sendReq.Content, sendReq.AllowedMentions = portal.parseMatrixHTML(content)
 		}
 
-		if content.EveryPizzaSpoiler {
+		if evt.Content.Raw["page.codeberg.everypizza.msc4193.spoiler"] == true {
 			filename = "SPOILER_" + filename
 		}
 

--- a/portal_convert.go
+++ b/portal_convert.go
@@ -155,8 +155,10 @@ func (portal *Portal) convertDiscordAttachment(ctx context.Context, intent *apps
 		},
 	}
 
+	var extra = make(map[string]any)
+
 	if strings.HasPrefix(att.Filename, "SPOILER_") {
-		content.EveryPizzaSpoiler = true
+		extra["page.codeberg.everypizza.msc4193.spoiler"] = true
 	}
 
 	if att.Description != "" {
@@ -164,19 +166,15 @@ func (portal *Portal) convertDiscordAttachment(ctx context.Context, intent *apps
 		content.FileName = att.Filename
 	}
 
-	var extra map[string]any
-
 	switch strings.ToLower(strings.Split(att.ContentType, "/")[0]) {
 	case "audio":
 		content.MsgType = event.MsgAudio
 		if att.Waveform != nil {
 			// TODO convert waveform
-			extra = map[string]any{
-				"org.matrix.msc1767.audio": map[string]any{
-					"duration": int(att.DurationSeconds * 1000),
-				},
-				"org.matrix.msc3245.voice": map[string]any{},
+			extra["org.matrix.msc1767.audio"] = map[string]any{
+				"duration": int(att.DurationSeconds * 1000),
 			}
+			extra["org.matrix.msc3245.voice"] = map[string]any{}
 		}
 	case "image":
 		content.MsgType = event.MsgImage

--- a/portal_convert.go
+++ b/portal_convert.go
@@ -154,6 +154,11 @@ func (portal *Portal) convertDiscordAttachment(ctx context.Context, intent *apps
 			Size: att.Size,
 		},
 	}
+
+	if strings.HasPrefix(att.Filename, "SPOILER_") {
+		content.EveryPizzaSpoiler = true
+	}
+
 	if att.Description != "" {
 		content.Body = att.Description
 		content.FileName = att.Filename


### PR DESCRIPTION
This adds support for rendering spoilers for uploaded files from or to Discord via [MSC4193](https://github.com/matrix-org/matrix-spec-proposals/pull/4193). Currently the only client I know of that implements this is Cinny:

![o8E7TS](https://github.com/user-attachments/assets/6ca291ee-e2e2-4cbc-bf17-ed100c9d4a67) ![1aGCPl](https://github.com/user-attachments/assets/97dc46bc-d033-4b0e-8bb1-95a36d3d2140)