### PR TITLE
Add support for ignoring specific webhooks from being bridged to Matrix

### DIFF
--- a/config/bridge.go
+++ b/config/bridge.go
@@ -40,22 +40,23 @@ type BridgeConfig struct {
 	PublicAddress  string `yaml:"public_address"`
 	AvatarProxyKey string `yaml:"avatar_proxy_key"`
 
-	DeliveryReceipts            bool `yaml:"delivery_receipts"`
-	MessageStatusEvents         bool `yaml:"message_status_events"`
-	MessageErrorNotices         bool `yaml:"message_error_notices"`
-	RestrictedRooms             bool `yaml:"restricted_rooms"`
-	AutojoinThreadOnOpen        bool `yaml:"autojoin_thread_on_open"`
-	EmbedFieldsAsTables         bool `yaml:"embed_fields_as_tables"`
-	MuteChannelsOnCreate        bool `yaml:"mute_channels_on_create"`
-	SyncDirectChatList          bool `yaml:"sync_direct_chat_list"`
-	ResendBridgeInfo            bool `yaml:"resend_bridge_info"`
-	CustomEmojiReactions        bool `yaml:"custom_emoji_reactions"`
-	DeletePortalOnChannelDelete bool `yaml:"delete_portal_on_channel_delete"`
-	DeleteGuildOnLeave          bool `yaml:"delete_guild_on_leave"`
-	FederateRooms               bool `yaml:"federate_rooms"`
-	PrefixWebhookMessages       bool `yaml:"prefix_webhook_messages"`
-	EnableWebhookAvatars        bool `yaml:"enable_webhook_avatars"`
-	UseDiscordCDNUpload         bool `yaml:"use_discord_cdn_upload"`
+	DeliveryReceipts            bool     `yaml:"delivery_receipts"`
+	MessageStatusEvents         bool     `yaml:"message_status_events"`
+	MessageErrorNotices         bool     `yaml:"message_error_notices"`
+	RestrictedRooms             bool     `yaml:"restricted_rooms"`
+	AutojoinThreadOnOpen        bool     `yaml:"autojoin_thread_on_open"`
+	EmbedFieldsAsTables         bool     `yaml:"embed_fields_as_tables"`
+	MuteChannelsOnCreate        bool     `yaml:"mute_channels_on_create"`
+	SyncDirectChatList          bool     `yaml:"sync_direct_chat_list"`
+	ResendBridgeInfo            bool     `yaml:"resend_bridge_info"`
+	CustomEmojiReactions        bool     `yaml:"custom_emoji_reactions"`
+	DeletePortalOnChannelDelete bool     `yaml:"delete_portal_on_channel_delete"`
+	DeleteGuildOnLeave          bool     `yaml:"delete_guild_on_leave"`
+	FederateRooms               bool     `yaml:"federate_rooms"`
+	PrefixWebhookMessages       bool     `yaml:"prefix_webhook_messages"`
+	EnableWebhookAvatars        bool     `yaml:"enable_webhook_avatars"`
+	UseDiscordCDNUpload         bool     `yaml:"use_discord_cdn_upload"`
+	IgnoredWebhooks             []string `yaml:"ignored_webhooks"`
 
 	Proxy string `yaml:"proxy"`
 

--- a/config/upgrade.go
+++ b/config/upgrade.go
@@ -63,6 +63,7 @@ func DoUpgrade(helper *up.Helper) {
 	helper.Copy(up.Bool, "bridge", "prefix_webhook_messages")
 	helper.Copy(up.Bool, "bridge", "enable_webhook_avatars")
 	helper.Copy(up.Bool, "bridge", "use_discord_cdn_upload")
+	helper.Copy(up.List, "bridge", "ignored_webhooks")
 	helper.Copy(up.Str|up.Null, "bridge", "proxy")
 	helper.Copy(up.Str, "bridge", "cache_media")
 	helper.Copy(up.Bool, "bridge", "direct_media", "enabled")

--- a/example-config.yaml
+++ b/example-config.yaml
@@ -171,6 +171,13 @@ bridge:
     # like the official client does? The other option is sending the media in the message send request as a form part
     # (which is always used by bots and webhooks).
     use_discord_cdn_upload: true
+    # List of Discord webhook IDs that will not be bridged to Matrix.
+    # Examples:
+    #   ignored_webhooks: []                                            # (default) don't ignore any webhook messages
+    #   ignored_webhooks: ["123456789012345678"]                        # ignore only webhook with ID "123456789012345678"
+    #   ignored_webhooks: ["123456789012345678", "987654321098765432"]  # ignore webhooks with these IDs
+    #   ignored_webhooks: ["*"]                                         # ignore all webhook messages
+    ignored_webhooks: []
     # Proxy for Discord connections
     proxy:
     # Should mxc uris copied from Discord be cached?


### PR DESCRIPTION
This adds support for defining specific discord webhook IDs to not bridge to Matrix. This can be useful if you have other bridges and don't want them to conflict with each other.