### PR TITLE
Only send `CONNECTED` bridge state on `READY` or `RESUMED`

### DIFF
--- a/user.go
+++ b/user.go
@@ -807,6 +807,7 @@ func (user *User) subscribeGuilds(delay time.Duration) {
 func (user *User) resumeHandler(_ *discordgo.Resumed) {
 	user.log.Debug().Msg("Discord connection resumed")
 	user.subscribeGuilds(0 * time.Second)
+	user.BridgeState.Send(status.BridgeState{StateEvent: status.StateConnected})
 }
 
 func (user *User) addPrivateChannelToSpace(portal *Portal) bool {
@@ -1007,7 +1008,6 @@ func (user *User) connectedHandler(_ *discordgo.Connect) {
 	user.log.Debug().Msg("Connected to Discord")
 	if user.wasDisconnected {
 		user.wasDisconnected = false
-		user.BridgeState.Send(status.BridgeState{StateEvent: status.StateConnected})
 	}
 }
 


### PR DESCRIPTION
Because we dispatch the handling of events in their own goroutines, our handling of the "connected" synthesized event from discordgo can race with the one for READY. This can lead to a bogus bridge state (i.e. one lacking a `remote_id`) being sent if the READY handling doesn't have a chance to fix `remote_id` by setting `DiscordID` first.

Instead, just explicitly send the bridge state upon READY or RESUMED.

<!-- Make sure you read the contributing guidelines first:
https://docs.mau.fi/bridges/general/contributing.html -->
