### PR TITLE
user: send `errUserNotLoggedIn` if we can't bridge event from logged-out user

### DIFF
--- a/portal.go
+++ b/portal.go
@@ -1100,7 +1100,6 @@ func (portal *Portal) sendMatrixMessage(intent *appservice.IntentAPI, eventType 
 func (portal *Portal) handleMatrixMessages(msg portalMatrixMessage) {
 	portal.forwardBackfillLock.Lock()
 	defer portal.forwardBackfillLock.Unlock()
-
 	switch msg.evt.Type {
 	case event.EventMessage, event.EventSticker:
 		portal.handleMatrixMessage(msg.user, msg.evt)


### PR DESCRIPTION
Proactively sends a failed MSS when receiving Matrix events for a portal that's associated with a logged out user.