### PR TITLE
feat: suppress webhook mentions

### DIFF
--- a/config/bridge.go
+++ b/config/bridge.go
@@ -55,6 +55,7 @@ type BridgeConfig struct {
 	FederateRooms               bool `yaml:"federate_rooms"`
 	PrefixWebhookMessages       bool `yaml:"prefix_webhook_messages"`
 	EnableWebhookAvatars        bool `yaml:"enable_webhook_avatars"`
+	SuppressWebhookMentions     bool `yaml:"suppress_webhook_mentions"`
 	UseDiscordCDNUpload         bool `yaml:"use_discord_cdn_upload"`
 
 	Proxy string `yaml:"proxy"`

--- a/example-config.yaml
+++ b/example-config.yaml
@@ -167,6 +167,9 @@ bridge:
     prefix_webhook_messages: true
     # Bridge webhook avatars?
     enable_webhook_avatars: false
+    # Suppress all mentions when sending messages via webhook (relay mode)?
+    # This prevents the webhook from pinging users, roles, or @everyone/@here.
+    suppress_webhook_mentions: false
     # Should the bridge upload media to the Discord CDN directly before sending the message when using a user token,
     # like the official client does? The other option is sending the media in the message send request as a form part
     # (which is always used by bots and webhooks).

--- a/portal.go
+++ b/portal.go
@@ -1559,6 +1559,14 @@ func (portal *Portal) handleMatrixMessage(sender *User, evt *event.Event) {
 				// TODO save edit in message table
 				msg, err = sess.ChannelMessageEdit(edits.DiscordProtoChannelID(), edits.DiscordID, discordContent)
 			} else {
+				if portal.bridge.Config.Bridge.SuppressWebhookMentions {
+					allowedMentions = &discordgo.MessageAllowedMentions{
+						Parse:       []discordgo.AllowedMentionType{},
+						Users:       []string{},
+						Roles:       []string{},
+						RepliedUser: false,
+					}
+				}
 				msg, err = relayClient.WebhookMessageEdit(portal.RelayWebhookID, portal.RelayWebhookSecret, edits.DiscordID, &discordgo.WebhookEdit{
 					Content:         &discordContent,
 					AllowedMentions: allowedMentions,
@@ -1702,6 +1710,13 @@ func (portal *Portal) handleMatrixMessage(sender *User, evt *event.Event) {
 			}
 		} else {
 			sendReq.AllowedMentions = nil
+		}
+	} else if portal.bridge.Config.Bridge.SuppressWebhookMentions {
+		sendReq.AllowedMentions = &discordgo.MessageAllowedMentions{
+			Parse:       []discordgo.AllowedMentionType{},
+			Users:       []string{},
+			Roles:       []string{},
+			RepliedUser: false,
 		}
 	} else if strings.Contains(sendReq.Content, "@everyone") || strings.Contains(sendReq.Content, "@here") {
 		powerLevels, err := portal.MainIntent().PowerLevels(portal.MXID)


### PR DESCRIPTION
Adds a config option to suppress all mentions for webhook relays, as this didn't appear to be a feature currently.