### PR TITLE
Add POST /v1/delete-portals provisioning endpoint

### DIFF
--- a/database/userportal.go
+++ b/database/userportal.go
@@ -115,6 +115,15 @@ func (u *User) MarkNotInPortal(discordID string) {
 	}
 }
 
+func (u *User) DeleteAllPortalAssociations() {
+	query := `DELETE FROM user_portal WHERE user_mxid=$1`
+	_, err := u.db.Exec(query, u.MXID)
+	if err != nil {
+		u.log.Errorfln("Failed to delete all portal associations for %s: %v", u.MXID, err)
+		panic(err)
+	}
+}
+
 func (u *User) PortalHasOtherUsers(discordID string) (hasOtherUsers bool) {
 	query := `SELECT COUNT(*) > 0 FROM user_portal WHERE user_mxid<>$1 AND discord_id=$2`
 	err := u.db.QueryRow(query, u.MXID, discordID).Scan(&hasOtherUsers)


### PR DESCRIPTION
## Summary

- Add `POST /v1/delete-portals` provisioning endpoint
  that deletes all portals (DMs + guild channels) for a
  user, with optional `discord_id` body parameter for
  users that are not logged in.
- Add `deleteAllPortals` method on `User` that collects
  DM portals and guild portals (only guilds where the
  user is the sole bridge user), deletes them from the
  DB synchronously, then runs async Matrix room cleanup.
- Update `readyHandler` to call `deleteAllPortals` +
  `Logout` on the previous user when a duplicate Discord
  ID login is detected, ensuring stale portals are
  cleaned up before re-bridging.

## Test plan

- [ ] Call `POST /v1/delete-portals` as a logged-in user
      and verify DM portals and sole-user guild portals
      are deleted, response includes correct counts.
- [ ] Call `POST /v1/delete-portals` with `discord_id`
      in the body for a user that is not logged in and
      verify it works.
- [ ] Call without login and without `discord_id` and
      verify a 400 error is returned.
- [ ] Verify guild portals shared with other users are
      skipped (not deleted).
- [ ] Log in with a Discord ID already used by another
      Matrix user and verify the previous user's portals
      are cleaned up before the new user's portals are
      bridged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)