### PR TITLE
Integrate nicknames in templates

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -8,8 +8,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: ["1.24", "1.25"]
-    name: Lint ${{ matrix.go-version == '1.25' && '(latest)' || '(old)' }}
+        go-version: ["1.25", "1.26"]
+    name: Lint ${{ matrix.go-version == '1.26' && '(latest)' || '(old)' }}
 
     steps:
       - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+# v0.7.6 (2026-02-16)
+
+* Bumped minimum Go version to 1.25.
+* Updated Docker image to Alpine 3.23.
+* Added support for following tombstones.
+* Added support for disabling link previews in messages sent to Discord using
+  [MSC4095].
+* Added support for federation thumbnail endpoint when using direct media.
+* Disabled using `restricted` join rules by default.
+
+[MSC4095]: https://github.com/matrix-org/matrix-spec-proposals/pull/4095
+
 # v0.7.5 (2025-07-16)
 
 * Fixed federation key response when using direct media.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1-alpine3.22 AS builder
+FROM golang:1-alpine3.23 AS builder
 
 RUN apk add --no-cache git ca-certificates build-base su-exec olm-dev
 
@@ -6,7 +6,7 @@ COPY . /build
 WORKDIR /build
 RUN go build -o /usr/bin/mautrix-discord
 
-FROM alpine:3.22
+FROM alpine:3.23
 
 ENV UID=1337 \
     GID=1337
@@ -17,5 +17,6 @@ COPY --from=builder /usr/bin/mautrix-discord /usr/bin/mautrix-discord
 COPY --from=builder /build/example-config.yaml /opt/mautrix-discord/example-config.yaml
 COPY --from=builder /build/docker-run.sh /docker-run.sh
 VOLUME /data
+WORKDIR /data
 
 CMD ["/docker-run.sh"]

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,4 +1,4 @@
-FROM alpine:3.22
+FROM alpine:3.23
 
 ENV UID=1337 \
     GID=1337
@@ -10,5 +10,6 @@ COPY $EXECUTABLE /usr/bin/mautrix-discord
 COPY ./example-config.yaml /opt/mautrix-discord/example-config.yaml
 COPY ./docker-run.sh /docker-run.sh
 VOLUME /data
+WORKDIR /data
 
 CMD ["/docker-run.sh"]

--- a/backfill.go
+++ b/backfill.go
@@ -275,7 +275,7 @@ func (portal *Portal) convertMessageBatch(log zerolog.Logger, source *User, mess
 			Int("message_type", int(msg.Type)).
 			Str("author_id", msg.Author.ID).
 			Logger()
-		parts := portal.convertDiscordMessage(log.WithContext(ctx), puppet, intent, msg)
+		parts := portal.convertDiscordMessage(log.WithContext(ctx), puppet, intent, msg, source)
 		for i, part := range parts {
 			if (replyTo != nil || threadRootEvent != "") && part.Content.RelatesTo == nil {
 				part.Content.RelatesTo = &event.RelatesTo{}

--- a/config/bridge.go
+++ b/config/bridge.go
@@ -202,6 +202,7 @@ type DisplaynameParams struct {
 	*discordgo.User
 	Webhook     bool
 	Application bool
+	Nickname    string
 }
 
 func (bc BridgeConfig) FormatDisplayname(user *discordgo.User, webhook, application bool) string {
@@ -220,6 +221,7 @@ type ChannelNameParams struct {
 	GuildName  string
 	NSFW       bool
 	Type       discordgo.ChannelType
+	Nickname   string
 }
 
 func (bc BridgeConfig) FormatChannelName(params ChannelNameParams) string {

--- a/config/bridge.go
+++ b/config/bridge.go
@@ -205,12 +205,13 @@ type DisplaynameParams struct {
 	Nickname    string
 }
 
-func (bc BridgeConfig) FormatDisplayname(user *discordgo.User, webhook, application bool) string {
+func (bc BridgeConfig) FormatDisplayname(user *discordgo.User, webhook, application bool, nickname string) string {
 	var buffer strings.Builder
 	_ = bc.displaynameTemplate.Execute(&buffer, &DisplaynameParams{
 		User:        user,
 		Webhook:     webhook,
 		Application: application,
+		Nickname:    nickname,
 	})
 	return buffer.String()
 }

--- a/config/bridge.go
+++ b/config/bridge.go
@@ -200,29 +200,29 @@ func (bc BridgeConfig) FormatUsername(userID string) string {
 
 type DisplaynameParams struct {
 	*discordgo.User
-	Webhook     bool
-	Application bool
-	Nickname    string
+	Webhook        bool
+	Application    bool
+	FriendNickname string
 }
 
 func (bc BridgeConfig) FormatDisplayname(user *discordgo.User, webhook, application bool, nickname string) string {
 	var buffer strings.Builder
 	_ = bc.displaynameTemplate.Execute(&buffer, &DisplaynameParams{
-		User:        user,
-		Webhook:     webhook,
-		Application: application,
-		Nickname:    nickname,
+		User:           user,
+		Webhook:        webhook,
+		Application:    application,
+		FriendNickname: nickname,
 	})
 	return buffer.String()
 }
 
 type ChannelNameParams struct {
-	Name       string
-	ParentName string
-	GuildName  string
-	NSFW       bool
-	Type       discordgo.ChannelType
-	Nickname   string
+	Name           string
+	ParentName     string
+	GuildName      string
+	NSFW           bool
+	Type           discordgo.ChannelType
+	FriendNickname string
 }
 
 func (bc BridgeConfig) FormatChannelName(params ChannelNameParams) string {

--- a/database/json.go
+++ b/database/json.go
@@ -1,0 +1,20 @@
+package database
+
+import (
+	"go.mau.fi/util/dbutil"
+)
+
+// Backported from mautrix/go-util@e5cb5e96d15cb87ffe6e5970c2f90ee47980e715.
+
+// JSONPtr is a convenience function for wrapping a pointer to a value in the JSON utility, but removing typed nils
+// (i.e. preventing nils from turning into the string "null" in the database).
+func JSONPtr[T any](val *T) dbutil.JSON {
+	return dbutil.JSON{Data: UntypedNil(val)}
+}
+
+func UntypedNil[T any](val *T) any {
+	if val == nil {
+		return nil
+	}
+	return val
+}

--- a/database/upgrades/00-latest-revision.sql
+++ b/database/upgrades/00-latest-revision.sql
@@ -1,4 +1,4 @@
--- v0 -> v23 (compatible with v19+): Latest revision
+-- v0 -> v24 (compatible with v19+): Latest revision
 
 CREATE TABLE guild (
     dcid       TEXT PRIMARY KEY,
@@ -92,7 +92,8 @@ CREATE TABLE "user" (
     space_room      TEXT,
     dm_space_room   TEXT,
 
-    read_state_version INTEGER NOT NULL DEFAULT 0
+    read_state_version INTEGER NOT NULL DEFAULT 0,
+    heartbeat_session jsonb
 );
 
 CREATE TABLE user_portal (

--- a/database/upgrades/24-user-heartbeat-session.sql
+++ b/database/upgrades/24-user-heartbeat-session.sql
@@ -1,0 +1,2 @@
+-- v24 (compatible with v19+): Add persisted heartbeat sessions
+ALTER TABLE "user" ADD COLUMN heartbeat_session jsonb;

--- a/database/user.go
+++ b/database/user.go
@@ -3,6 +3,7 @@ package database
 import (
 	"database/sql"
 
+	"github.com/bwmarrin/discordgo"
 	"go.mau.fi/util/dbutil"
 	log "maunium.net/go/maulogger/v2"
 	"maunium.net/go/mautrix/id"
@@ -21,18 +22,18 @@ func (uq *UserQuery) New() *User {
 }
 
 func (uq *UserQuery) GetByMXID(userID id.UserID) *User {
-	query := `SELECT mxid, dcid, discord_token, management_room, space_room, dm_space_room, read_state_version FROM "user" WHERE mxid=$1`
+	query := `SELECT mxid, dcid, discord_token, management_room, space_room, dm_space_room, read_state_version, heartbeat_session FROM "user" WHERE mxid=$1`
 	return uq.New().Scan(uq.db.QueryRow(query, userID))
 }
 
 func (uq *UserQuery) GetByID(id string) *User {
-	query := `SELECT mxid, dcid, discord_token, management_room, space_room, dm_space_room, read_state_version FROM "user" WHERE dcid=$1`
+	query := `SELECT mxid, dcid, discord_token, management_room, space_room, dm_space_room, read_state_version, heartbeat_session FROM "user" WHERE dcid=$1`
 	return uq.New().Scan(uq.db.QueryRow(query, id))
 }
 
 func (uq *UserQuery) GetAllWithToken() []*User {
 	query := `
-		SELECT mxid, dcid, discord_token, management_room, space_room, dm_space_room, read_state_version
+		SELECT mxid, dcid, discord_token, management_room, space_room, dm_space_room, read_state_version, heartbeat_session
 		FROM "user" WHERE discord_token IS NOT NULL
 	`
 	rows, err := uq.db.Query(query)
@@ -54,19 +55,20 @@ type User struct {
 	db  *Database
 	log log.Logger
 
-	MXID           id.UserID
-	DiscordID      string
-	DiscordToken   string
-	ManagementRoom id.RoomID
-	SpaceRoom      id.RoomID
-	DMSpaceRoom    id.RoomID
+	MXID             id.UserID
+	DiscordID        string
+	DiscordToken     string
+	ManagementRoom   id.RoomID
+	SpaceRoom        id.RoomID
+	DMSpaceRoom      id.RoomID
+	HeartbeatSession *discordgo.HeartbeatSession
 
 	ReadStateVersion int
 }
 
 func (u *User) Scan(row dbutil.Scannable) *User {
 	var discordID, managementRoom, spaceRoom, dmSpaceRoom, discordToken sql.NullString
-	err := row.Scan(&u.MXID, &discordID, &discordToken, &managementRoom, &spaceRoom, &dmSpaceRoom, &u.ReadStateVersion)
+	err := row.Scan(&u.MXID, &discordID, &discordToken, &managementRoom, &spaceRoom, &dmSpaceRoom, &u.ReadStateVersion, dbutil.JSON{Data: &u.HeartbeatSession})
 	if err != nil {
 		if err != sql.ErrNoRows {
 			u.log.Errorln("Database scan failed:", err)
@@ -83,8 +85,8 @@ func (u *User) Scan(row dbutil.Scannable) *User {
 }
 
 func (u *User) Insert() {
-	query := `INSERT INTO "user" (mxid, dcid, discord_token, management_room, space_room, dm_space_room, read_state_version) VALUES ($1, $2, $3, $4, $5, $6, $7)`
-	_, err := u.db.Exec(query, u.MXID, strPtr(u.DiscordID), strPtr(u.DiscordToken), strPtr(string(u.ManagementRoom)), strPtr(string(u.SpaceRoom)), strPtr(string(u.DMSpaceRoom)), u.ReadStateVersion)
+	query := `INSERT INTO "user" (mxid, dcid, discord_token, management_room, space_room, dm_space_room, read_state_version, heartbeat_session) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`
+	_, err := u.db.Exec(query, u.MXID, strPtr(u.DiscordID), strPtr(u.DiscordToken), strPtr(string(u.ManagementRoom)), strPtr(string(u.SpaceRoom)), strPtr(string(u.DMSpaceRoom)), u.ReadStateVersion, JSONPtr(u.HeartbeatSession))
 	if err != nil {
 		u.log.Warnfln("Failed to insert %s: %v", u.MXID, err)
 		panic(err)
@@ -92,8 +94,8 @@ func (u *User) Insert() {
 }
 
 func (u *User) Update() {
-	query := `UPDATE "user" SET dcid=$1, discord_token=$2, management_room=$3, space_room=$4, dm_space_room=$5, read_state_version=$6 WHERE mxid=$7`
-	_, err := u.db.Exec(query, strPtr(u.DiscordID), strPtr(u.DiscordToken), strPtr(string(u.ManagementRoom)), strPtr(string(u.SpaceRoom)), strPtr(string(u.DMSpaceRoom)), u.ReadStateVersion, u.MXID)
+	query := `UPDATE "user" SET dcid=$1, discord_token=$2, management_room=$3, space_room=$4, dm_space_room=$5, read_state_version=$6, heartbeat_session=$7 WHERE mxid=$8`
+	_, err := u.db.Exec(query, strPtr(u.DiscordID), strPtr(u.DiscordToken), strPtr(string(u.ManagementRoom)), strPtr(string(u.SpaceRoom)), strPtr(string(u.DMSpaceRoom)), u.ReadStateVersion, JSONPtr(u.HeartbeatSession), u.MXID)
 	if err != nil {
 		u.log.Warnfln("Failed to update %q: %v", u.MXID, err)
 		panic(err)

--- a/directmedia.go
+++ b/directmedia.go
@@ -154,6 +154,7 @@ func newDirectMediaAPI(br *DiscordBridge) *DirectMediaAPI {
 	addRoutes("r0")
 	addRoutes("v1")
 	federationRouter.HandleFunc("/v1/media/download/{mediaID}", dma.DownloadMedia).Methods(http.MethodGet)
+	federationRouter.HandleFunc("/v1/media/thumbnail/{mediaID}", dma.DownloadMedia).Methods(http.MethodGet)
 	federationRouter.HandleFunc("/v1/version", dma.ks.GetServerVersion).Methods(http.MethodGet)
 	mediaRouter.NotFoundHandler = http.HandlerFunc(dma.UnknownEndpoint)
 	mediaRouter.MethodNotAllowedHandler = http.HandlerFunc(dma.UnsupportedMethod)
@@ -556,7 +557,7 @@ func (dma *DirectMediaAPI) proxyDownload(ctx context.Context, w http.ResponseWri
 func (dma *DirectMediaAPI) DownloadMedia(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	log := zerolog.Ctx(ctx)
-	isNewFederation := strings.HasPrefix(r.URL.Path, "/_matrix/federation/v1/media/download/")
+	isNewFederation := strings.HasPrefix(r.URL.Path, "/_matrix/federation/v1/media/")
 	vars := mux.Vars(r)
 	if !isNewFederation && vars["serverName"] != dma.cfg.ServerName {
 		jsonResponse(w, http.StatusNotFound, &mautrix.RespError{

--- a/example-config.yaml
+++ b/example-config.yaml
@@ -130,7 +130,7 @@ bridge:
     message_error_notices: true
     # Should the bridge use space-restricted join rules instead of invite-only for guild rooms?
     # This can avoid unnecessary invite events in guild rooms when members are synced in.
-    restricted_rooms: true
+    restricted_rooms: false
     # Should the bridge automatically join the user to threads on Discord when the thread is opened on Matrix?
     # This only works with clients that support thread read receipts (MSC3771 added in Matrix v1.4).
     autojoin_thread_on_open: true

--- a/example-config.yaml
+++ b/example-config.yaml
@@ -91,7 +91,7 @@ bridge:
     #   .System - Whether the user is an official system user
     #   .Webhook - Whether the user is a webhook and is not an application
     #   .Application - Whether the user is an application
-    #   .FriendNickname - The Discord relationship nickname ("friend nick") for this user. Empty if no friend nickname is set.
+    #   .FriendNickname - The Discord relationship nickname ("friend nick") for this user. Empty if no friend nickname is set. Available in both DM and guild contexts.
     displayname_template: '{{if .Webhook}}Webhook{{else}}{{or .GlobalName .Username}}{{if .Bot}} (bot){{end}}{{end}}'
     # Displayname template for Discord channels (bridged as rooms, or spaces when type=4).
     # Available variables:

--- a/example-config.yaml
+++ b/example-config.yaml
@@ -91,6 +91,7 @@ bridge:
     #   .System - Whether the user is an official system user
     #   .Webhook - Whether the user is a webhook and is not an application
     #   .Application - Whether the user is an application
+    #   .Nickname - The Discord relationship nickname ("friend nick"), per logged-in user. Typically available for DMs.
     displayname_template: '{{if .Webhook}}Webhook{{else}}{{or .GlobalName .Username}}{{if .Bot}} (bot){{end}}{{end}}'
     # Displayname template for Discord channels (bridged as rooms, or spaces when type=4).
     # Available variables:
@@ -99,7 +100,8 @@ bridge:
     #   .GuildName - Guild name.
     #   .NSFW - Whether the channel is marked as NSFW.
     #   .Type - Channel type (see values at https://github.com/bwmarrin/discordgo/blob/v0.25.0/structs.go#L251-L267)
-    channel_name_template: '{{if or (eq .Type 3) (eq .Type 4)}}{{.Name}}{{else}}#{{.Name}}{{end}}'
+    #   .Nickname - The Discord relationship nickname ("friend nick"), per logged-in user. Available for DMs (type=1).
+    channel_name_template: '{{if eq .Type 1}}{{or .Nickname .Name}}{{else if or (eq .Type 3) (eq .Type 4)}}{{.Name}}{{else}}#{{.Name}}{{end}}'
     # Displayname template for Discord guilds (bridged as spaces).
     # Available variables:
     #   .Name - Guild name

--- a/example-config.yaml
+++ b/example-config.yaml
@@ -91,7 +91,7 @@ bridge:
     #   .System - Whether the user is an official system user
     #   .Webhook - Whether the user is a webhook and is not an application
     #   .Application - Whether the user is an application
-    #   .Nickname - The Discord relationship nickname ("friend nick"), per logged-in user. Typically available for DMs.
+    #   .Nickname - The Discord relationship nickname ("friend nick"), only available in DMs. Guild nicknames are not exposed to templates.
     displayname_template: '{{if .Webhook}}Webhook{{else}}{{or .GlobalName .Username}}{{if .Bot}} (bot){{end}}{{end}}'
     # Displayname template for Discord channels (bridged as rooms, or spaces when type=4).
     # Available variables:
@@ -100,7 +100,7 @@ bridge:
     #   .GuildName - Guild name.
     #   .NSFW - Whether the channel is marked as NSFW.
     #   .Type - Channel type (see values at https://github.com/bwmarrin/discordgo/blob/v0.25.0/structs.go#L251-L267)
-    #   .Nickname - The Discord relationship nickname ("friend nick"), per logged-in user. Available for DMs (type=1).
+    #   .Nickname - The Discord relationship nickname ("friend nick"), only available in DMs (type=1). Guild nicknames are not exposed to templates.
     channel_name_template: '{{if eq .Type 1}}{{or .Nickname .Name}}{{else if or (eq .Type 3) (eq .Type 4)}}{{.Name}}{{else}}#{{.Name}}{{end}}'
     # Displayname template for Discord guilds (bridged as spaces).
     # Available variables:

--- a/example-config.yaml
+++ b/example-config.yaml
@@ -91,7 +91,7 @@ bridge:
     #   .System - Whether the user is an official system user
     #   .Webhook - Whether the user is a webhook and is not an application
     #   .Application - Whether the user is an application
-    #   .Nickname - The Discord relationship nickname ("friend nick"), only available in DMs. Guild nicknames are not exposed to templates.
+    #   .FriendNickname - The Discord relationship nickname ("friend nick") for this user. Empty if no friend nickname is set.
     displayname_template: '{{if .Webhook}}Webhook{{else}}{{or .GlobalName .Username}}{{if .Bot}} (bot){{end}}{{end}}'
     # Displayname template for Discord channels (bridged as rooms, or spaces when type=4).
     # Available variables:
@@ -100,8 +100,8 @@ bridge:
     #   .GuildName - Guild name.
     #   .NSFW - Whether the channel is marked as NSFW.
     #   .Type - Channel type (see values at https://github.com/bwmarrin/discordgo/blob/v0.25.0/structs.go#L251-L267)
-    #   .Nickname - The Discord relationship nickname ("friend nick"), only available in DMs (type=1). Guild nicknames are not exposed to templates.
-    channel_name_template: '{{if eq .Type 1}}{{or .Nickname .Name}}{{else if or (eq .Type 3) (eq .Type 4)}}{{.Name}}{{else}}#{{.Name}}{{end}}'
+    #   .FriendNickname - The Discord relationship nickname ("friend nick") for this user. Only non-empty for DMs (type=1). Guild nicknames are not exposed to templates.
+    channel_name_template: '{{if eq .Type 1}}{{or .FriendNickname .Name}}{{else if or (eq .Type 3) (eq .Type 4)}}{{.Name}}{{else}}#{{.Name}}{{end}}'
     # Displayname template for Discord guilds (bridged as spaces).
     # Available variables:
     #   .Name - Guild name

--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 require (
 	github.com/coreos/go-systemd/v22 v22.5.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/google/uuid v1.6.0 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.19 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
@@ -42,4 +43,4 @@ require (
 	maunium.net/go/mauflag v1.0.0 // indirect
 )
 
-replace github.com/bwmarrin/discordgo => github.com/beeper/discordgo v0.0.0-20251029151721-c53d6229e2fd
+replace github.com/bwmarrin/discordgo => github.com/beeper/discordgo v0.0.0-20251117165013-20c39e9899ec

--- a/go.mod
+++ b/go.mod
@@ -43,4 +43,4 @@ require (
 	maunium.net/go/mauflag v1.0.0 // indirect
 )
 
-replace github.com/bwmarrin/discordgo => github.com/beeper/discordgo v0.0.0-20251117165013-20c39e9899ec
+replace github.com/bwmarrin/discordgo => github.com/beeper/discordgo v0.0.0-20251125191000-08af68849c99

--- a/go.mod
+++ b/go.mod
@@ -42,4 +42,4 @@ require (
 	maunium.net/go/mauflag v1.0.0 // indirect
 )
 
-replace github.com/bwmarrin/discordgo => github.com/beeper/discordgo v0.0.0-20250607214857-f23a8518ece2
+replace github.com/bwmarrin/discordgo => github.com/beeper/discordgo v0.0.0-20251029151721-c53d6229e2fd

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module go.mau.fi/mautrix-discord
 
-go 1.24.0
+go 1.25.0
 
-toolchain go1.25.0
+toolchain go1.26.0
 
 require (
 	github.com/bwmarrin/discordgo v0.27.0

--- a/go.mod
+++ b/go.mod
@@ -43,4 +43,4 @@ require (
 	maunium.net/go/mauflag v1.0.0 // indirect
 )
 
-replace github.com/bwmarrin/discordgo => github.com/beeper/discordgo v0.0.0-20251125191000-08af68849c99
+replace github.com/bwmarrin/discordgo => github.com/beeper/discordgo v0.0.0-20260215125047-ccf8cbaa0a9f

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/DATA-DOG/go-sqlmock v1.5.0 h1:Shsta01QNfFxHCfpW6YH2STWB0MudeXXEWMr20OEh60=
 github.com/DATA-DOG/go-sqlmock v1.5.0/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
-github.com/beeper/discordgo v0.0.0-20250607214857-f23a8518ece2 h1:8lgTjYGSIlS90f0jiFfEC4UwxCq9FiUo4dKwjknbupQ=
-github.com/beeper/discordgo v0.0.0-20250607214857-f23a8518ece2/go.mod h1:59+AOzzjmL6onAh62nuLXmn7dJCaC/owDLWbGtjTcFA=
+github.com/beeper/discordgo v0.0.0-20251029151721-c53d6229e2fd h1:RXB0a8lTNN9vB838lZXm11inXwvILpOzXi3j978P8RE=
+github.com/beeper/discordgo v0.0.0-20251029151721-c53d6229e2fd/go.mod h1:59+AOzzjmL6onAh62nuLXmn7dJCaC/owDLWbGtjTcFA=
 github.com/coreos/go-systemd/v22 v22.5.0 h1:RrqgGjYQKalulkV8NGVIfkXQf6YYmOyiJKk8iXXhfZs=
 github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/DATA-DOG/go-sqlmock v1.5.0 h1:Shsta01QNfFxHCfpW6YH2STWB0MudeXXEWMr20OEh60=
 github.com/DATA-DOG/go-sqlmock v1.5.0/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
-github.com/beeper/discordgo v0.0.0-20251117165013-20c39e9899ec h1:5yvEHHd6f4GharWjdBVCjdvL0C09h9wZlayBaI75q1I=
-github.com/beeper/discordgo v0.0.0-20251117165013-20c39e9899ec/go.mod h1:lioivnibvB8j1KcF5TVpLdRLKCKHtcl8A03GpxRCre4=
+github.com/beeper/discordgo v0.0.0-20251125191000-08af68849c99 h1:uLpNLE/Avs+XMOzbjh49MfWuqm2lo+Z8Kv07CjOdRWQ=
+github.com/beeper/discordgo v0.0.0-20251125191000-08af68849c99/go.mod h1:lioivnibvB8j1KcF5TVpLdRLKCKHtcl8A03GpxRCre4=
 github.com/coreos/go-systemd/v22 v22.5.0 h1:RrqgGjYQKalulkV8NGVIfkXQf6YYmOyiJKk8iXXhfZs=
 github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/DATA-DOG/go-sqlmock v1.5.0 h1:Shsta01QNfFxHCfpW6YH2STWB0MudeXXEWMr20OEh60=
 github.com/DATA-DOG/go-sqlmock v1.5.0/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
-github.com/beeper/discordgo v0.0.0-20251029151721-c53d6229e2fd h1:RXB0a8lTNN9vB838lZXm11inXwvILpOzXi3j978P8RE=
-github.com/beeper/discordgo v0.0.0-20251029151721-c53d6229e2fd/go.mod h1:59+AOzzjmL6onAh62nuLXmn7dJCaC/owDLWbGtjTcFA=
+github.com/beeper/discordgo v0.0.0-20251117165013-20c39e9899ec h1:5yvEHHd6f4GharWjdBVCjdvL0C09h9wZlayBaI75q1I=
+github.com/beeper/discordgo v0.0.0-20251117165013-20c39e9899ec/go.mod h1:lioivnibvB8j1KcF5TVpLdRLKCKHtcl8A03GpxRCre4=
 github.com/coreos/go-systemd/v22 v22.5.0 h1:RrqgGjYQKalulkV8NGVIfkXQf6YYmOyiJKk8iXXhfZs=
 github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -11,6 +11,8 @@ github.com/gabriel-vasile/mimetype v1.4.9/go.mod h1:WnSQhFKJuBlRyLiKohA/2DtIlPFA
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWmnc=

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/DATA-DOG/go-sqlmock v1.5.0 h1:Shsta01QNfFxHCfpW6YH2STWB0MudeXXEWMr20OEh60=
 github.com/DATA-DOG/go-sqlmock v1.5.0/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
-github.com/beeper/discordgo v0.0.0-20251125191000-08af68849c99 h1:uLpNLE/Avs+XMOzbjh49MfWuqm2lo+Z8Kv07CjOdRWQ=
-github.com/beeper/discordgo v0.0.0-20251125191000-08af68849c99/go.mod h1:lioivnibvB8j1KcF5TVpLdRLKCKHtcl8A03GpxRCre4=
+github.com/beeper/discordgo v0.0.0-20260215125047-ccf8cbaa0a9f h1:A+SRmETpSnFixbP1x6u7sQdoi8cOuYfL5bkDJy9F/Pg=
+github.com/beeper/discordgo v0.0.0-20260215125047-ccf8cbaa0a9f/go.mod h1:lioivnibvB8j1KcF5TVpLdRLKCKHtcl8A03GpxRCre4=
 github.com/coreos/go-systemd/v22 v22.5.0 h1:RrqgGjYQKalulkV8NGVIfkXQf6YYmOyiJKk8iXXhfZs=
 github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/main.go
+++ b/main.go
@@ -187,7 +187,7 @@ func main() {
 		Name:              "mautrix-discord",
 		URL:               "https://github.com/mautrix/discord",
 		Description:       "A Matrix-Discord puppeting bridge.",
-		Version:           "0.7.5",
+		Version:           "0.7.6",
 		ProtocolName:      "Discord",
 		BeeperServiceName: "discordgo",
 		BeeperNetworkName: "discord",

--- a/portal.go
+++ b/portal.go
@@ -1653,16 +1653,21 @@ func (portal *Portal) handleMatrixMessage(sender *User, evt *event.Event) {
 
 		if portal.bridge.Config.Bridge.UseDiscordCDNUpload && !isWebhookSend && sess.IsUser {
 			att := &discordgo.MessageAttachment{
-				ID:          "0",
-				Filename:    filename,
-				Description: description,
+				ID:                  "0",
+				Filename:            filename,
+				Description:         description,
+				OriginalContentType: content.Info.MimeType,
 			}
 			sendReq.Attachments = []*discordgo.MessageAttachment{att}
+			isClip := false
 			prep, err := sender.Session.ChannelAttachmentCreate(channelID, &discordgo.ReqPrepareAttachments{
 				Files: []*discordgo.FilePrepare{{
 					Size: len(data),
 					Name: att.Filename,
 					ID:   sender.NextDiscordUploadID(),
+
+					IsClip:              &isClip,
+					OriginalContentType: att.OriginalContentType,
 				}},
 			}, portal.RefererOpt(threadID))
 			if err != nil {

--- a/portal.go
+++ b/portal.go
@@ -1522,9 +1522,15 @@ func (portal *Portal) RefererOptIfUser(sess *discordgo.Session, threadID string)
 }
 
 func (portal *Portal) handleMatrixMessage(sender *User, evt *event.Event) {
-	if portal.IsPrivateChat() && sender.DiscordID != portal.Key.Receiver {
-		go portal.sendMessageMetrics(evt, errUserNotReceiver, "Ignoring")
-		return
+	if portal.IsPrivateChat() {
+		if !sender.IsLoggedIn() {
+			go portal.sendMessageMetrics(evt, errUserNotLoggedIn, "Ignoring")
+			return
+		}
+		if sender.DiscordID != portal.Key.Receiver {
+			go portal.sendMessageMetrics(evt, errUserNotReceiver, "Ignoring")
+			return
+		}
 	}
 
 	content, ok := evt.Content.Parsed.(*event.MessageEventContent)
@@ -1918,11 +1924,12 @@ func (portal *Portal) getMatrixUsers() ([]id.UserID, error) {
 }
 
 func (portal *Portal) handleMatrixReaction(sender *User, evt *event.Event) {
+	if !sender.IsLoggedIn() {
+		go portal.sendMessageMetrics(evt, errUserNotLoggedIn, "Ignoring")
+		return
+	}
 	if portal.IsPrivateChat() && sender.DiscordID != portal.Key.Receiver {
 		go portal.sendMessageMetrics(evt, errUserNotReceiver, "Ignoring")
-		return
-	} else if !sender.IsLoggedIn() {
-		//go portal.sendMessageMetrics(evt, errReactionUserNotLoggedIn, "Ignoring")
 		return
 	}
 
@@ -2101,9 +2108,15 @@ func (portal *Portal) handleDiscordReaction(user *User, reaction *discordgo.Mess
 }
 
 func (portal *Portal) handleMatrixRedaction(sender *User, evt *event.Event) {
-	if portal.IsPrivateChat() && sender.DiscordID != portal.Key.Receiver {
-		go portal.sendMessageMetrics(evt, errUserNotReceiver, "Ignoring")
-		return
+	if portal.IsPrivateChat() {
+		if !sender.IsLoggedIn() {
+			go portal.sendMessageMetrics(evt, errUserNotLoggedIn, "Ignoring")
+			return
+		}
+		if sender.DiscordID != portal.Key.Receiver {
+			go portal.sendMessageMetrics(evt, errUserNotReceiver, "Ignoring")
+			return
+		}
 	}
 
 	sess := sender.Session

--- a/portal.go
+++ b/portal.go
@@ -2551,9 +2551,9 @@ func (portal *Portal) UpdateInfo(source *User, meta *discordgo.Channel) *discord
 				changed = true
 			}
 			changed = portal.UpdateNameDirect(portal.bridge.Config.Bridge.FormatChannelName(config.ChannelNameParams{
-				Name:     puppet.Name,
-				Nickname: nickname,
-				Type:     discordgo.ChannelTypeDM,
+				Name:           puppet.Name,
+				FriendNickname: nickname,
+				Type:           discordgo.ChannelTypeDM,
 			}), nickname != "") || changed
 		}
 		if portal.MXID != "" {

--- a/portal.go
+++ b/portal.go
@@ -660,7 +660,7 @@ func (portal *Portal) handleDiscordMessageCreate(user *User, msg *discordgo.Mess
 	mentions := portal.convertDiscordMentions(msg, true)
 
 	ts, _ := discordgo.SnowflakeTimestamp(msg.ID)
-	parts := portal.convertDiscordMessage(ctx, puppet, intent, msg)
+	parts := portal.convertDiscordMessage(ctx, puppet, intent, msg, user)
 	dbParts := make([]database.MessagePart, 0, len(parts))
 	eventIDs := zerolog.Dict()
 	for i, part := range parts {
@@ -924,7 +924,7 @@ func (portal *Portal) handleDiscordMessageUpdate(user *User, msg *discordgo.Mess
 		return
 	}
 	puppet.addWebhookMeta(converted, msg)
-	puppet.addMemberMeta(converted, msg)
+	puppet.addMemberMeta(converted, msg, user)
 	converted.Content.Mentions = portal.convertDiscordMentions(msg, false)
 	converted.Content.SetEdit(existing[0].MXID)
 	// Never actually mention new users of edits, only include mentions inside m.new_content

--- a/portal.go
+++ b/portal.go
@@ -2541,13 +2541,20 @@ func (portal *Portal) UpdateInfo(source *User, meta *discordgo.Channel) *discord
 		if portal.OtherUserID != "" {
 			puppet := portal.bridge.GetPuppetByID(portal.OtherUserID)
 			changed = portal.UpdateAvatarFromPuppet(puppet) || changed
-			if rel, ok := source.relationships[portal.OtherUserID]; ok && rel.Nickname != "" {
-				portal.FriendNick = true
-				changed = portal.UpdateNameDirect(rel.Nickname, true) || changed
-			} else {
-				portal.FriendNick = false
-				changed = portal.UpdateNameDirect(puppet.Name, false) || changed
+			var nickname string
+			if rel, ok := source.relationships[portal.OtherUserID]; ok {
+				nickname = rel.Nickname
 			}
+			prevFriendNick := portal.FriendNick
+			portal.FriendNick = nickname != ""
+			if prevFriendNick != portal.FriendNick {
+				changed = true
+			}
+			changed = portal.UpdateNameDirect(portal.bridge.Config.Bridge.FormatChannelName(config.ChannelNameParams{
+				Name:     puppet.Name,
+				Nickname: nickname,
+				Type:     discordgo.ChannelTypeDM,
+			}), nickname != "") || changed
 		}
 		if portal.MXID != "" {
 			portal.syncParticipants(source, meta.Recipients)

--- a/portal_convert.go
+++ b/portal_convert.go
@@ -375,19 +375,30 @@ func (puppet *Puppet) addMemberMeta(part *ConvertedMessage, msg *discordgo.Messa
 		"avatar_url": discordAvatarURL,
 		"avatar_mxc": avatarURL.String(),
 	}
-	if msg.Member.Nick != "" || !avatarURL.IsEmpty() {
-		perMessageProfile := map[string]any{
-			"id":          fmt.Sprintf("%s_%s", msg.GuildID, msg.Author.ID),
-			"displayname": msg.Member.Nick,
-			"avatar_url":  avatarURL.String(),
+	var friendNickname string
+	if source != nil {
+		if rel, ok := source.relationships[msg.Author.ID]; ok {
+			friendNickname = rel.Nickname
 		}
-		if msg.Member.Nick == "" {
-			perMessageProfile["displayname"] = puppet.Name
+	}
+	if msg.Member.Nick != "" || !avatarURL.IsEmpty() || friendNickname != "" {
+		var displayname string
+		if friendNickname != "" {
+			displayname = puppet.bridge.Config.Bridge.FormatDisplayname(msg.Author, puppet.IsWebhook, puppet.IsApplication, friendNickname)
+		} else if msg.Member.Nick != "" {
+			displayname = msg.Member.Nick
+		} else {
+			displayname = puppet.Name
 		}
+		avatarStr := avatarURL.String()
 		if avatarURL.IsEmpty() {
-			perMessageProfile["avatar_url"] = puppet.AvatarURL.String()
+			avatarStr = puppet.AvatarURL.String()
 		}
-		part.Extra["com.beeper.per_message_profile"] = perMessageProfile
+		part.Extra["com.beeper.per_message_profile"] = map[string]any{
+			"id":          fmt.Sprintf("%s_%s", msg.GuildID, msg.Author.ID),
+			"displayname": displayname,
+			"avatar_url":  avatarStr,
+		}
 	}
 }
 

--- a/portal_convert.go
+++ b/portal_convert.go
@@ -376,17 +376,13 @@ func (puppet *Puppet) addMemberMeta(part *ConvertedMessage, msg *discordgo.Messa
 		"avatar_mxc": avatarURL.String(),
 	}
 	if msg.Member.Nick != "" || !avatarURL.IsEmpty() {
-		nick := msg.Member.Nick
-		var displayname string
-		if nick != "" {
-			displayname = puppet.bridge.Config.Bridge.FormatDisplayname(msg.Author, puppet.IsWebhook, puppet.IsApplication, nick)
-		} else {
-			displayname = puppet.Name
-		}
 		perMessageProfile := map[string]any{
 			"id":          fmt.Sprintf("%s_%s", msg.GuildID, msg.Author.ID),
-			"displayname": displayname,
+			"displayname": msg.Member.Nick,
 			"avatar_url":  avatarURL.String(),
+		}
+		if msg.Member.Nick == "" {
+			perMessageProfile["displayname"] = puppet.Name
 		}
 		if avatarURL.IsEmpty() {
 			perMessageProfile["avatar_url"] = puppet.AvatarURL.String()

--- a/portal_convert.go
+++ b/portal_convert.go
@@ -363,13 +363,17 @@ func (puppet *Puppet) addMemberMeta(part *ConvertedMessage, msg *discordgo.Messa
 		"avatar_mxc": avatarURL.String(),
 	}
 	if msg.Member.Nick != "" || !avatarURL.IsEmpty() {
+		nick := msg.Member.Nick
+		var displayname string
+		if nick != "" {
+			displayname = puppet.bridge.Config.Bridge.FormatDisplayname(msg.Author, puppet.IsWebhook, puppet.IsApplication, nick)
+		} else {
+			displayname = puppet.Name
+		}
 		perMessageProfile := map[string]any{
 			"id":          fmt.Sprintf("%s_%s", msg.GuildID, msg.Author.ID),
-			"displayname": msg.Member.Nick,
+			"displayname": displayname,
 			"avatar_url":  avatarURL.String(),
-		}
-		if msg.Member.Nick == "" {
-			perMessageProfile["displayname"] = puppet.Name
 		}
 		if avatarURL.IsEmpty() {
 			perMessageProfile["avatar_url"] = puppet.AvatarURL.String()

--- a/portal_convert.go
+++ b/portal_convert.go
@@ -274,7 +274,7 @@ func (portal *Portal) convertDiscordVideoEmbed(ctx context.Context, intent *apps
 	}
 }
 
-func (portal *Portal) convertDiscordMessage(ctx context.Context, puppet *Puppet, intent *appservice.IntentAPI, msg *discordgo.Message) []*ConvertedMessage {
+func (portal *Portal) convertDiscordMessage(ctx context.Context, puppet *Puppet, intent *appservice.IntentAPI, msg *discordgo.Message, source *User) []*ConvertedMessage {
 	predictedLength := len(msg.Attachments) + len(msg.StickerItems)
 	if msg.Content != "" {
 		predictedLength++
@@ -333,13 +333,26 @@ func (portal *Portal) convertDiscordMessage(ctx context.Context, puppet *Puppet,
 	}
 	for _, part := range parts {
 		puppet.addWebhookMeta(part, msg)
-		puppet.addMemberMeta(part, msg)
+		puppet.addMemberMeta(part, msg, source)
 	}
 	return parts
 }
 
-func (puppet *Puppet) addMemberMeta(part *ConvertedMessage, msg *discordgo.Message) {
+func (puppet *Puppet) addMemberMeta(part *ConvertedMessage, msg *discordgo.Message, source *User) {
 	if msg.Member == nil {
+		if source != nil {
+			if rel, ok := source.relationships[msg.Author.ID]; ok && rel.Nickname != "" {
+				if part.Extra == nil {
+					part.Extra = make(map[string]any)
+				}
+				displayname := puppet.bridge.Config.Bridge.FormatDisplayname(msg.Author, puppet.IsWebhook, puppet.IsApplication, rel.Nickname)
+				part.Extra["com.beeper.per_message_profile"] = map[string]any{
+					"id":          msg.Author.ID,
+					"displayname": displayname,
+					"avatar_url":  puppet.AvatarURL.String(),
+				}
+			}
+		}
 		return
 	}
 	if part.Extra == nil {

--- a/puppet.go
+++ b/puppet.go
@@ -196,7 +196,7 @@ func (puppet *Puppet) updatePortalMeta(meta func(portal *Portal)) {
 }
 
 func (puppet *Puppet) UpdateName(info *discordgo.User) bool {
-	newName := puppet.bridge.Config.Bridge.FormatDisplayname(info, puppet.IsWebhook, puppet.IsApplication)
+	newName := puppet.bridge.Config.Bridge.FormatDisplayname(info, puppet.IsWebhook, puppet.IsApplication, "")
 	if puppet.Name == newName && puppet.NameSet {
 		return false
 	}

--- a/puppet.go
+++ b/puppet.go
@@ -14,6 +14,7 @@ import (
 	"maunium.net/go/mautrix/bridge"
 	"maunium.net/go/mautrix/id"
 
+	"go.mau.fi/mautrix-discord/config"
 	"go.mau.fi/mautrix-discord/database"
 )
 
@@ -206,7 +207,15 @@ func (puppet *Puppet) UpdateName(info *discordgo.User) bool {
 		puppet.log.Warn().Err(err).Msg("Failed to update displayname")
 	} else {
 		go puppet.updatePortalMeta(func(portal *Portal) {
-			if portal.UpdateNameDirect(puppet.Name, false) {
+			// Friend nicknames take precedence over puppet name updates.
+			// When the nickname is removed, handleRelationshipChange will recompute the name.
+			if portal.FriendNick {
+				return
+			}
+			if portal.UpdateNameDirect(portal.bridge.Config.Bridge.FormatChannelName(config.ChannelNameParams{
+				Name: puppet.Name,
+				Type: discordgo.ChannelTypeDM,
+			}), false) {
 				portal.Update()
 				portal.UpdateBridgeInfo()
 			}

--- a/puppet.go
+++ b/puppet.go
@@ -195,8 +195,20 @@ func (puppet *Puppet) updatePortalMeta(meta func(portal *Portal)) {
 	}
 }
 
-func (puppet *Puppet) UpdateName(info *discordgo.User) bool {
-	newName := puppet.bridge.Config.Bridge.FormatDisplayname(info, puppet.IsWebhook, puppet.IsApplication, "")
+// toDiscordUser reconstructs a minimal discordgo.User from the puppet's stored fields.
+// Used when updating the display name without a live discordgo.User object available.
+func (puppet *Puppet) toDiscordUser() *discordgo.User {
+	return &discordgo.User{
+		ID:            puppet.ID,
+		Username:      puppet.Username,
+		GlobalName:    puppet.GlobalName,
+		Discriminator: puppet.Discriminator,
+		Bot:           puppet.IsBot,
+	}
+}
+
+func (puppet *Puppet) UpdateName(info *discordgo.User, nickname string) bool {
+	newName := puppet.bridge.Config.Bridge.FormatDisplayname(info, puppet.IsWebhook, puppet.IsApplication, nickname)
 	if puppet.Name == newName && puppet.NameSet {
 		return false
 	}
@@ -333,7 +345,13 @@ func (puppet *Puppet) UpdateInfo(source *User, info *discordgo.User, message *di
 		}
 	}
 	changed = puppet.UpdateContactInfo(info) || changed
-	changed = puppet.UpdateName(info) || changed
+	var nickname string
+	if source != nil {
+		if rel, ok := source.relationships[info.ID]; ok {
+			nickname = rel.Nickname
+		}
+	}
+	changed = puppet.UpdateName(info, nickname) || changed
 	changed = puppet.UpdateAvatar(info) || changed
 	if changed {
 		puppet.Update()

--- a/user.go
+++ b/user.go
@@ -807,6 +807,7 @@ func (user *User) subscribeGuilds(delay time.Duration) {
 func (user *User) resumeHandler(_ *discordgo.Resumed) {
 	user.log.Debug().Msg("Discord connection resumed")
 	user.subscribeGuilds(0 * time.Second)
+	user.BridgeState.Send(status.BridgeState{StateEvent: status.StateConnected})
 }
 
 func (user *User) addPrivateChannelToSpace(portal *Portal) bool {
@@ -1007,7 +1008,6 @@ func (user *User) connectedHandler(_ *discordgo.Connect) {
 	user.log.Debug().Msg("Connected to Discord")
 	if user.wasDisconnected {
 		user.wasDisconnected = false
-		user.BridgeState.Send(status.BridgeState{StateEvent: status.StateConnected})
 	}
 }
 

--- a/user.go
+++ b/user.go
@@ -870,6 +870,12 @@ func (user *User) handleRelationshipChange(userID, nickname string) {
 	prevFriendNick := portal.FriendNick
 	portal.FriendNick = nickname != ""
 
+	// Update the puppet's Matrix display name using the nickname via displayname_template.
+	// This must happen before FormatChannelName so puppet.Name reflects the new state.
+	if puppetChanged := puppet.UpdateName(puppet.toDiscordUser(), nickname); puppetChanged {
+		puppet.Update()
+	}
+
 	if nickname != "" || portal.shouldSetDMRoomMetadata() {
 		formattedName := portal.bridge.Config.Bridge.FormatChannelName(config.ChannelNameParams{
 			Name:     puppet.Name,

--- a/user.go
+++ b/user.go
@@ -30,6 +30,7 @@ import (
 	"maunium.net/go/mautrix/id"
 	"maunium.net/go/mautrix/pushrules"
 
+	"go.mau.fi/mautrix-discord/config"
 	"go.mau.fi/mautrix-discord/database"
 )
 
@@ -866,28 +867,26 @@ func (user *User) handleRelationshipChange(userID, nickname string) {
 		return
 	}
 
-	updated := portal.FriendNick == (nickname != "")
+	prevFriendNick := portal.FriendNick
 	portal.FriendNick = nickname != ""
-	if nickname != "" {
-		updated = portal.UpdateNameDirect(nickname, true)
-	} else if portal.Name != puppet.Name {
-		if portal.shouldSetDMRoomMetadata() {
-			updated = portal.UpdateNameDirect(puppet.Name, false)
-		} else if portal.NameSet {
-			_, err := portal.MainIntent().SendStateEvent(portal.MXID, event.StateRoomName, "", map[string]any{})
-			if err != nil {
-				portal.log.Warn().Err(err).Msg("Failed to clear room name after friend nickname was removed")
-			} else {
-				portal.log.Debug().Msg("Cleared room name after friend nickname was removed")
-				portal.NameSet = false
-				portal.Update()
-				updated = true
-			}
+
+	if nickname != "" || portal.shouldSetDMRoomMetadata() {
+		formattedName := portal.bridge.Config.Bridge.FormatChannelName(config.ChannelNameParams{
+			Name:     puppet.Name,
+			Nickname: nickname,
+			Type:     discordgo.ChannelTypeDM,
+		})
+		portal.UpdateNameDirect(formattedName, nickname != "")
+	} else if prevFriendNick && portal.NameSet && portal.MXID != "" {
+		_, err := portal.MainIntent().SendStateEvent(portal.MXID, event.StateRoomName, "", map[string]any{})
+		if err != nil {
+			portal.log.Warn().Err(err).Msg("Failed to clear room name after friend nickname was removed")
+		} else {
+			portal.log.Debug().Msg("Cleared room name after friend nickname was removed")
+			portal.NameSet = false
 		}
 	}
-	if !updated {
-		portal.Update()
-	}
+	portal.Update()
 }
 
 func (user *User) handlePrivateChannel(portal *Portal, meta *discordgo.Channel, timestamp time.Time, create, isInSpace bool) {

--- a/user.go
+++ b/user.go
@@ -878,9 +878,9 @@ func (user *User) handleRelationshipChange(userID, nickname string) {
 
 	if nickname != "" || portal.shouldSetDMRoomMetadata() {
 		formattedName := portal.bridge.Config.Bridge.FormatChannelName(config.ChannelNameParams{
-			Name:     puppet.Name,
-			Nickname: nickname,
-			Type:     discordgo.ChannelTypeDM,
+			Name:           puppet.Name,
+			FriendNickname: nickname,
+			Type:           discordgo.ChannelTypeDM,
 		})
 		portal.UpdateNameDirect(formattedName, nickname != "")
 	} else if prevFriendNick && portal.NameSet && portal.MXID != "" {


### PR DESCRIPTION
**Disclaimer:** This was made with AI. I've not really got any deep understanding of the codebase nor of the language go. But I've looked at the changes and they make sense to me. Additionally I've tested them by building the container myself:

```
 mautrix-discord:
    build:
      context: "https://github.com/BierDav/discord.git#copilot/add-nickname-template-variable"
      dockerfile: Dockerfile
    restart: unless-stopped
  ```


----

This changes should properly integrate nicknames a discord user can give to their friends in the DM section support into the existing template definitions for channel names and display names, because they currently weren't either customizable or not available at all. I tried to ensure that the config base is update so that the behaviour of the current version stays the same. The new variable `.FriendNickname` is available in DM and Guild contexts, but returns in both cases the same value, namely the nickname from the DM section.