### PR TITLE
Added support for Discord Forum channels

### DIFF
--- a/discord.go
+++ b/discord.go
@@ -8,7 +8,7 @@ import (
 
 func (user *User) channelIsBridgeable(channel *discordgo.Channel) bool {
 	switch channel.Type {
-	case discordgo.ChannelTypeGuildText, discordgo.ChannelTypeGuildNews:
+	case discordgo.ChannelTypeGuildText, discordgo.ChannelTypeGuildNews, discordgo.ChannelTypeGuildForum:
 		// allowed
 	case discordgo.ChannelTypeDM, discordgo.ChannelTypeGroupDM:
 		// DMs are always bridgeable, no need for permission checks

--- a/portal.go
+++ b/portal.go
@@ -448,7 +448,7 @@ func (portal *Portal) CreateMatrixRoom(user *User, channel *discordgo.Channel) e
 	}
 
 	creationContent := make(map[string]interface{})
-	if portal.Type == discordgo.ChannelTypeGuildCategory {
+	if portal.Type == discordgo.ChannelTypeGuildCategory || portal.Type == discordgo.ChannelTypeGuildForum {
 		creationContent["type"] = event.RoomTypeSpace
 	}
 	if !portal.bridge.Config.Bridge.FederateRooms {
@@ -559,7 +559,116 @@ func (portal *Portal) CreateMatrixRoom(user *User, channel *discordgo.Channel) e
 	go portal.forwardBackfillInitial(user, nil)
 	backfillStarted = true
 
+	if portal.Type == discordgo.ChannelTypeGuildForum {
+		go portal.backfillForumThreads(user)
+	}
+
 	return nil
+}
+
+func (portal *Portal) backfillForumThreads(user *User) {
+	if portal.MXID == "" {
+		return
+	}
+
+	activeThreads, err := user.Session.ThreadsActive(portal.Key.ChannelID)
+	if err != nil {
+		portal.log.Err(err).Msg("Failed to get active forum threads")
+	} else {
+		for _, threadMeta := range activeThreads.Threads {
+			portal.handleNewForumThread(user, threadMeta)
+		}
+	}
+
+	// NOTE: Discord API have a weird limitation on archived threads, they can only be fetched
+	//   per group of 100, so we use the before argument and a loop to fetch them all
+	archivedLimit := 100
+	var before *time.Time = nil
+	for {
+		archivedThreads, err := user.Session.ThreadsArchived(portal.Key.ChannelID, before, archivedLimit)
+		if err != nil {
+			portal.log.Err(err).Msg("Failed to get archived forum threads")
+			break
+		}
+		if len(archivedThreads.Threads) == 0 {
+			break
+		}
+
+		for _, threadMeta := range archivedThreads.Threads {
+			portal.handleNewForumThread(user, threadMeta)
+		}
+
+		if !archivedThreads.HasMore {
+			break
+		}
+
+		oldestThread := archivedThreads.Threads[len(archivedThreads.Threads)-1]
+		if oldestThread.ThreadMetadata == nil {
+			portal.log.Warn().Str("thread_id", oldestThread.ID).Msg("Thread metadata is nil, stopping pagination")
+			break
+		}
+		before = &oldestThread.ThreadMetadata.ArchiveTimestamp
+		portal.log.Debug().Str("before", before.String()).Msg("Fetching next page of archived threads")
+	}
+}
+
+func (portal *Portal) handleNewForumThread(user *User, threadMeta *discordgo.Channel) {
+	portal.log.Debug().Str("thread_id", threadMeta.ID).Str("thread_name", threadMeta.Name).Msg("Processing forum thread")
+
+	if threadMeta.MessageCount == 0 {
+		portal.log.Warn().Str("thread_id", threadMeta.ID).Msg("Forum thread has no messages")
+		return
+	}
+
+	threadPortal := portal.bridge.GetPortalByID(database.NewPortalKey(threadMeta.ID, ""), discordgo.ChannelTypeGuildPublicThread)
+	if threadPortal.MXID != "" {
+		portal.log.Debug().Str("thread_id", threadMeta.ID).Str("room_id", threadPortal.MXID.String()).Msg("Thread portal already exists")
+		return
+	}
+
+	threadPortal.GuildID = portal.GuildID
+	threadPortal.Guild = portal.Guild
+	threadPortal.ParentID = portal.Key.ChannelID
+	threadPortal.Parent = portal
+
+	err := threadPortal.CreateMatrixRoom(user, threadMeta)
+	if err != nil {
+		portal.log.Err(err).Str("thread_id", threadMeta.ID).Msg("Failed to create Matrix room for forum thread")
+		return
+	}
+
+	threadPortal.updateSpace(user)
+
+	msg, err := user.Session.ChannelMessage(threadMeta.ID, threadMeta.LastMessageID)
+	if err != nil {
+		portal.log.Err(err).Str("thread_id", threadMeta.ID).Msg("Failed to get last message for thread registration")
+	} else {
+		ts, _ := discordgo.SnowflakeTimestamp(msg.ID)
+		rootMsg := portal.bridge.DB.Message.GetByDiscordID(threadPortal.Key, msg.ID)
+		if len(rootMsg) == 0 {
+			puppet := portal.bridge.GetPuppetByID(msg.Author.ID)
+			puppet.UpdateInfo(user, msg.Author, msg)
+
+			parts := portal.convertDiscordMessage(context.Background(), puppet, puppet.IntentFor(portal), msg)
+			dbParts := make([]database.MessagePart, 0, len(parts))
+			for _, part := range parts {
+				resp, err := portal.sendMatrixMessage(puppet.IntentFor(portal), part.Type, part.Content, part.Extra, ts.UnixMilli())
+				if err != nil {
+					portal.log.Err(err).Str("part_index", part.AttachmentID).Msg("Failed to send forum thread root message to Matrix")
+					continue
+				}
+				dbParts = append(dbParts, database.MessagePart{AttachmentID: part.AttachmentID, MXID: resp.EventID})
+			}
+			if len(dbParts) > 0 {
+				rootMsg = []*database.Message{portal.markMessageHandled(msg.ID, msg.Author.ID, ts, threadMeta.ID, puppet.MXID, dbParts)}
+			}
+		}
+		if len(rootMsg) > 0 {
+			portal.bridge.threadFound(context.Background(), user, rootMsg[0], threadMeta.ID, threadMeta)
+		}
+	}
+
+	portal.log.Debug().Str("thread_id", threadMeta.ID).Str("room_id", threadPortal.MXID.String()).Msg("Created Matrix room for forum thread")
 }
 
 func (portal *Portal) handleDiscordMessages(msg portalDiscordMessage) {

--- a/user.go
+++ b/user.go
@@ -715,6 +715,12 @@ func (user *User) eventHandler(rawEvt any) {
 		user.interactionSuccessHandler(evt)
 	case *discordgo.ThreadListSync:
 		user.threadListSyncHandler(evt)
+	case *discordgo.ThreadCreate:
+		user.threadCreateHandler(evt)
+	case *discordgo.ThreadDelete:
+		user.threadDeleteHandler(evt)
+	case *discordgo.ThreadUpdate:
+		user.threadUpdateHandler(evt)
 	case *discordgo.Event:
 		// Ignore
 	default:
@@ -1146,6 +1152,147 @@ func (user *User) threadListSyncHandler(t *discordgo.ThreadListSync) {
 			thread.Parent.ForwardBackfillMissed(user, meta.LastMessageID, thread)
 		}
 	}
+}
+
+func (user *User) threadCreateHandler(t *discordgo.ThreadCreate) {
+	log := user.log.With().
+		Str("action", "thread create").
+		Str("guild_id", t.GuildID).
+		Str("thread_id", t.ID).
+		Str("parent_id", t.ParentID).
+		Logger()
+	ctx := log.WithContext(context.Background())
+
+	parentChannel, err := user.Session.Channel(t.ParentID)
+	if err != nil {
+		log.Err(err).Msg("Failed to get parent channel")
+		return
+	}
+
+	if parentChannel.Type != discordgo.ChannelTypeGuildForum {
+		log.Debug().Msg("Thread create in non-forum channel, skipping")
+		return
+	}
+
+	if user.getGuildBridgingMode(t.GuildID) < database.GuildBridgeEverything {
+		log.Debug().Msg("Ignoring thread create in unbridged guild")
+		return
+	}
+
+	forumPortal := user.GetPortalByMeta(parentChannel)
+	if forumPortal.MXID == "" {
+		log.Debug().Msg("Forum portal not created yet, creating")
+		if err := forumPortal.CreateMatrixRoom(user, parentChannel); err != nil {
+			log.Err(err).Msg("Failed to create forum portal")
+			return
+		}
+	}
+
+	threadPortal := user.bridge.GetPortalByID(database.NewPortalKey(t.ID, ""), discordgo.ChannelTypeGuildPublicThread)
+	if threadPortal.MXID != "" {
+		log.Debug().Str("room_id", threadPortal.MXID.String()).Msg("Thread portal already exists")
+		return
+	}
+
+	threadPortal.GuildID = t.GuildID
+	threadPortal.ParentID = t.ParentID
+	threadPortal.Parent = forumPortal
+	if guild := user.bridge.GetGuildByID(t.GuildID, false); guild != nil {
+		threadPortal.Guild = guild
+	}
+
+	log.Info().Msg("Creating Matrix room for new forum thread")
+	if err := threadPortal.CreateMatrixRoom(user, t.Channel); err != nil {
+		log.Err(err).Msg("Failed to create Matrix room for forum thread")
+		return
+	}
+
+	threadPortal.updateSpace(user)
+
+	msg, err := user.Session.ChannelMessage(t.ID, t.LastMessageID)
+	if err != nil {
+		log.Err(err).Msg("Failed to get last message for thread registration")
+		return
+	}
+
+	ts, _ := discordgo.SnowflakeTimestamp(msg.ID)
+	rootMsg := user.bridge.DB.Message.GetByDiscordID(threadPortal.Key, msg.ID)
+	if len(rootMsg) == 0 {
+		puppet := user.bridge.GetPuppetByID(msg.Author.ID)
+		puppet.UpdateInfo(user, msg.Author, msg)
+
+		intent := puppet.IntentFor(threadPortal)
+		parts := threadPortal.convertDiscordMessage(ctx, puppet, intent, msg)
+		dbParts := make([]database.MessagePart, 0, len(parts))
+		for _, part := range parts {
+			resp, err := threadPortal.sendMatrixMessage(intent, part.Type, part.Content, part.Extra, ts.UnixMilli())
+			if err != nil {
+				log.Err(err).Msg("Failed to send forum thread root message to Matrix")
+				continue
+			}
+			dbParts = append(dbParts, database.MessagePart{AttachmentID: part.AttachmentID, MXID: resp.EventID})
+		}
+		if len(dbParts) > 0 {
+			rootMsg = []*database.Message{threadPortal.markMessageHandled(msg.ID, msg.Author.ID, ts, t.ID, puppet.MXID, dbParts)}
+		}
+	}
+	if len(rootMsg) > 0 {
+		user.bridge.threadFound(ctx, user, rootMsg[0], t.ID, t.Channel)
+	}
+
+	log.Info().Str("room_id", threadPortal.MXID.String()).Msg("Created Matrix room for new forum thread")
+}
+
+func (user *User) threadDeleteHandler(t *discordgo.ThreadDelete) {
+	log := user.log.With().
+		Str("action", "thread delete").
+		Str("guild_id", t.GuildID).
+		Str("thread_id", t.ID).
+		Str("parent_id", t.ParentID).
+		Logger()
+
+	threadPortal := user.bridge.GetExistingPortalByID(database.NewPortalKey(t.ID, ""))
+	if threadPortal == nil {
+		log.Debug().Msg("Ignoring thread delete event of unknown thread")
+		return
+	}
+
+	log.Info().Str("room_id", threadPortal.MXID.String()).Msg("Got thread delete event, cleaning up portal")
+	threadPortal.Delete()
+	threadPortal.cleanup(true)
+	log.Info().Msg("Completed cleaning up thread")
+}
+
+func (user *User) threadUpdateHandler(t *discordgo.ThreadUpdate) {
+	log := user.log.With().
+		Str("action", "thread update").
+		Str("guild_id", t.GuildID).
+		Str("thread_id", t.ID).
+		Str("parent_id", t.ParentID).
+		Logger()
+
+	threadPortal := user.bridge.GetExistingPortalByID(database.NewPortalKey(t.ID, ""))
+	if threadPortal == nil || threadPortal.MXID == "" {
+		log.Debug().Msg("Ignoring thread update event of unknown thread or thread without portal")
+		return
+	}
+
+	if t.Channel == nil || t.Channel.Name == "" {
+		log.Debug().Msg("Thread update has no name, skipping")
+		return
+	}
+
+	log.Info().Str("old_name", threadPortal.Name).Str("new_name", t.Channel.Name).Msg("Updating thread name")
+
+	_, err := threadPortal.MainIntent().SetRoomName(threadPortal.MXID, t.Channel.Name)
+	if err != nil {
+		log.Err(err).Msg("Failed to update thread room name")
+		return
+	}
+
+	threadPortal.Name = t.Channel.Name
+	threadPortal.Update()
+	log.Info().Msg("Thread room name updated")
 }
 
 func (user *User) channelCreateHandler(c *discordgo.ChannelCreate) {


### PR DESCRIPTION
# Changes

This patch aims to fix https://github.com/mautrix/discord/issues/101 by adding support for Discord Forum type channel to the Matrix Discord Bridge.

## Motivation

Discord added some years ago a feature exclusive to "community servers" that allows special channel of type "Forum" to be created, in which users can exclusively create new threads to discuss a subject.

While #217 also try to fix this issue, it seems to stay very manual in its approach and does not support "Automatic bridging of all forum threads", which is an issue for usage like mine where this project is used to save and duplicate Discord servers. 

## Implementation

The forums are bridged by creating a space for each forum and creating a room for each thread inside.

While having a Matrix room with only Matrix threads inside would be "technically closer" to how Discord works, having a space for the forum make it easier and cleaner to read like how Discord categories are bridged as Matrix spaces too. 

## Improvements

- Discord forums have additional data like their tags, which does not really have any equivalent in Matrix. They could maybe be preserved by adding custom events data on the thread rooms?
- Other users may not want all the old threads to be bridged, especially if they are used for simple help tickets. Additional configuration fields could be added to let the administrator decide their preferred behaviors.

## Tests

- I was able to fully bridge my Discord servers with all my previous threads properly backfilled
- Creating and deleting threads was properly registered on Matrix
- Sending messages in Discord or in Matrix properly replicated it on the other side

I want to note that I do not really have uses for "Double Puppeting" or anything that goes from Matrix toward Discord, I use this project to backup and archive my Discord servers and therefore could not make sure that those features were properly handled.

--- 

# Checklist

* [x] I have read and followed the contributing guidelines at <https://docs.mau.fi/bridges/general/contributing.html>
