### PR TITLE
handlematrix: allow DMs in already-accepted message requests

### DIFF
--- a/pkg/connector/handlematrix.go
+++ b/pkg/connector/handlematrix.go
@@ -181,7 +181,11 @@ func (d *DiscordClient) screenOutgoingMessage(ctx context.Context, destCh *disco
 
 			dmRecip := d.userCache.Resolve(ctx, *dmRecipID)
 
-			if dmRecip != nil && !dmRecip.Bot && !friendsWithDMRecip {
+			// IsMessageRequest is Discord's own "is this a stranger?" signal — false means
+			// Discord has accepted the conversation, even when the two users aren't friends.
+			isAcceptedDM := destCh != nil && !destCh.IsMessageRequest
+
+			if dmRecip != nil && !dmRecip.Bot && !friendsWithDMRecip && !isAcceptedDM {
 				loggedRelType := "none"
 				if rel != nil {
 					loggedRelType = readableRelationshipType(rel.Type)


### PR DESCRIPTION
## Summary

`screenOutgoingMessage` rejects sends in any DM where the two users aren't formal Discord friends, including DMs the recipient has explicitly accepted as a message request. Once accepted, Discord flips `Channel.IsMessageRequest` to `false`, signaling the conversation is sanctioned for both parties — but the gate ignores this signal.

## Repro (Beeper PLAT-36375)

A user (`tobiah`) received a DM from a non-friend on May 9, accepted it in the Discord client, and then exchanged **~150 inbound / ~87 outbound messages** with that user over five days. Every send attempted through Beeper was rejected with `can't direct message a stranger` because the gate only checks `RelationshipFriend`.

Bridge log at the moment of failure:

```
{"level":"info","action":"matrix message send","relationship_type":"none","message":"Preventing direct message send to a stranger"}
{"level":"error","error":"can't direct message a stranger","message":"Failed to handle Matrix message"}
```

## Fix

Trust `IsMessageRequest=false` as an additional acceptance signal alongside `RelationshipFriend`. It covers both never-was-a-request DMs and recipient-accepted requests, without weakening the gate for cold DMs (where the channel either doesn't exist yet — `destCh == nil` — or has `IsMessageRequest` still `true`).

```go
isAcceptedDM := destCh != nil && !destCh.IsMessageRequest

if dmRecip != nil && !dmRecip.Bot && !friendsWithDMRecip && !isAcceptedDM {
    // ... reject ...
}
```

`Channel.IsMessageRequest` was added to `beeper/discordgo` in 87daff93 and pulled into this branch by 1ab2788, so the field is already populated on cached Channels via `READY` / `READY_SUPPLEMENTAL.lazy_private_channels` / `CHANNEL_CREATE` / `CHANNEL_UPDATE`.

## Out of scope

This does **not** auto-accept pending message requests on the user's behalf when they reply via the bridge to a still-unaccepted incoming DM (which would call `PUT /channels/{channel.id}/recipients/@me {consent_status: 2}` before the send, mirroring what the Discord client does). That's a separate change with broader UX implications and can be a follow-up if desired — Tobiah's case is fully covered by reading the field that's already there.

## Test plan

- [ ] Build passes (`go build ./...` ✓ locally).
- [ ] `vet` passes (`go vet ./pkg/connector/...` ✓ locally).
- [ ] Manual: cold-DM a non-friend on a fresh DM channel → still rejected with `can't direct message a stranger` (gate intact for the dangerous case).
- [ ] Manual: receive a DM from a non-friend, accept in Discord client, reply via Beeper → send goes through.
- [ ] No new test file added — there are no existing unit tests under `pkg/connector/` for `screenOutgoingMessage` to extend; matches the pattern of the original 5f1cbbc backport.