### PR TITLE
Bridge Discord call state notices

### DIFF
--- a/pkg/connector/call_state.go
+++ b/pkg/connector/call_state.go
@@ -1,0 +1,200 @@
+// mautrix-discord - A Matrix-Discord puppeting bridge.
+// Copyright (C) 2026 Tulir Asokan
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package connector
+
+import (
+	"context"
+	"slices"
+	"sync"
+
+	"github.com/bwmarrin/discordgo"
+	"maunium.net/go/mautrix/bridgev2"
+)
+
+type discordCallState struct {
+	lock               sync.Mutex
+	activeByChannel    map[string]*discordgo.Message
+	voiceChannelByUser map[string]string
+}
+
+func newDiscordCallState() *discordCallState {
+	return &discordCallState{
+		activeByChannel:    make(map[string]*discordgo.Message),
+		voiceChannelByUser: make(map[string]string),
+	}
+}
+
+func (s *discordCallState) UpdateFromMessage(msg *discordgo.Message) {
+	if s == nil || msg == nil || msg.Type != discordgo.MessageTypeCall || msg.ChannelID == "" {
+		return
+	}
+
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	if msg.Call == nil || msg.Call.EndedTimestamp != nil {
+		s.removeChannelLocked(msg.ChannelID)
+		return
+	}
+
+	s.removeStaleParticipantMappingsLocked(msg.ChannelID, msg.Call.Participants)
+	active := cloneDiscordCallMessage(msg)
+	s.activeByChannel[msg.ChannelID] = active
+	for _, userID := range active.Call.Participants {
+		s.voiceChannelByUser[userID] = msg.ChannelID
+	}
+}
+
+func (s *discordCallState) UpdateFromVoiceState(evt *discordgo.VoiceStateUpdate) []*discordgo.Message {
+	if s == nil || evt == nil || evt.VoiceState == nil || evt.UserID == "" {
+		return nil
+	}
+
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	var edits []*discordgo.Message
+	oldChannelID := s.voiceChannelByUser[evt.UserID]
+	if oldChannelID == "" && evt.BeforeUpdate != nil {
+		oldChannelID = evt.BeforeUpdate.ChannelID
+	}
+	newChannelID := evt.ChannelID
+
+	if oldChannelID != "" && oldChannelID != newChannelID {
+		if edit := s.removeParticipantLocked(oldChannelID, evt.UserID); edit != nil {
+			edits = append(edits, edit)
+		}
+	}
+
+	if newChannelID == "" {
+		delete(s.voiceChannelByUser, evt.UserID)
+		return edits
+	}
+
+	s.voiceChannelByUser[evt.UserID] = newChannelID
+	if edit := s.addParticipantLocked(newChannelID, evt.UserID); edit != nil {
+		edits = append(edits, edit)
+	}
+	return edits
+}
+
+func (s *discordCallState) removeChannelLocked(channelID string) {
+	if active := s.activeByChannel[channelID]; active != nil && active.Call != nil {
+		for _, userID := range active.Call.Participants {
+			if s.voiceChannelByUser[userID] == channelID {
+				delete(s.voiceChannelByUser, userID)
+			}
+		}
+	}
+	delete(s.activeByChannel, channelID)
+}
+
+func (s *discordCallState) removeStaleParticipantMappingsLocked(channelID string, participants []string) {
+	active := s.activeByChannel[channelID]
+	if active == nil || active.Call == nil {
+		return
+	}
+	for _, userID := range active.Call.Participants {
+		if !slices.Contains(participants, userID) && s.voiceChannelByUser[userID] == channelID {
+			delete(s.voiceChannelByUser, userID)
+		}
+	}
+}
+
+func (s *discordCallState) removeParticipantLocked(channelID, userID string) *discordgo.Message {
+	active := s.activeByChannel[channelID]
+	if active == nil || active.Call == nil {
+		return nil
+	}
+
+	participantIdx := slices.Index(active.Call.Participants, userID)
+	if participantIdx == -1 {
+		return nil
+	}
+	active.Call.Participants = slices.Delete(active.Call.Participants, participantIdx, participantIdx+1)
+	return cloneDiscordCallMessage(active)
+}
+
+func (s *discordCallState) addParticipantLocked(channelID, userID string) *discordgo.Message {
+	active := s.activeByChannel[channelID]
+	if active == nil || active.Call == nil || slices.Contains(active.Call.Participants, userID) {
+		return nil
+	}
+
+	active.Call.Participants = append(active.Call.Participants, userID)
+	return cloneDiscordCallMessage(active)
+}
+
+func cloneDiscordCallMessage(msg *discordgo.Message) *discordgo.Message {
+	if msg == nil {
+		return nil
+	}
+
+	clone := *msg
+	if msg.Author != nil {
+		author := *msg.Author
+		clone.Author = &author
+	}
+	if msg.Call != nil {
+		clone.Call = &discordgo.MessageCall{
+			Participants: append([]string(nil), msg.Call.Participants...),
+		}
+		if msg.Call.EndedTimestamp != nil {
+			endedTimestamp := *msg.Call.EndedTimestamp
+			clone.Call.EndedTimestamp = &endedTimestamp
+		}
+	}
+	return &clone
+}
+
+func (d *DiscordClient) trackDiscordCallMessage(msg *discordgo.Message) {
+	if d.callState != nil {
+		d.callState.UpdateFromMessage(msg)
+	}
+}
+
+func (d *DiscordClient) handleDiscordCallVoiceStateUpdate(ctx context.Context, evt *discordgo.VoiceStateUpdate) {
+	if d.callState == nil {
+		return
+	}
+
+	for _, msg := range d.callState.UpdateFromVoiceState(evt) {
+		d.queueDiscordCallStateEdit(ctx, msg)
+	}
+}
+
+func (d *DiscordClient) queueDiscordCallStateEdit(ctx context.Context, msg *discordgo.Message) {
+	if msg == nil || msg.ID == "" || msg.ChannelID == "" {
+		return
+	}
+
+	ctx, log := messageCtx(ctx, msg)
+	bridged, route := d.channelIsBridged(ctx, msg.ChannelID)
+	if !bridged {
+		return
+	}
+
+	participantCount := 0
+	if msg.Call != nil {
+		participantCount = len(msg.Call.Participants)
+	}
+	log.Debug().
+		Int("call_participant_count", participantCount).
+		Msg("Queueing Discord call state edit from voice state")
+	wrappedEvt := d.wrapDiscordMessage(ctx, msg, route, bridgev2.RemoteEventEdit)
+	d.UserLogin.Bridge.QueueRemoteEvent(d.UserLogin, &wrappedEvt)
+}

--- a/pkg/connector/call_state_test.go
+++ b/pkg/connector/call_state_test.go
@@ -1,0 +1,115 @@
+// mautrix-discord - A Matrix-Discord puppeting bridge.
+// Copyright (C) 2026 Tulir Asokan
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package connector
+
+import (
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/bwmarrin/discordgo"
+)
+
+func TestDiscordCallStateVoiceLeaveEditsActiveCall(t *testing.T) {
+	state := newDiscordCallState()
+	state.UpdateFromMessage(discordCallStateTestMessage("msg", "dm", "caller", "self"))
+
+	edits := state.UpdateFromVoiceState(&discordgo.VoiceStateUpdate{
+		VoiceState: &discordgo.VoiceState{UserID: "self", ChannelID: ""},
+	})
+	if len(edits) != 1 {
+		t.Fatalf("expected 1 edit, got %d", len(edits))
+	}
+	if !slices.Equal(edits[0].Call.Participants, []string{"caller"}) {
+		t.Fatalf("unexpected participants after leave: %v", edits[0].Call.Participants)
+	}
+
+	duplicateEdits := state.UpdateFromVoiceState(&discordgo.VoiceStateUpdate{
+		VoiceState: &discordgo.VoiceState{UserID: "self", ChannelID: ""},
+	})
+	if len(duplicateEdits) != 0 {
+		t.Fatalf("expected duplicate leave to be ignored, got %d edits", len(duplicateEdits))
+	}
+}
+
+func TestDiscordCallStateVoiceJoinEditsActiveCall(t *testing.T) {
+	state := newDiscordCallState()
+	state.UpdateFromMessage(discordCallStateTestMessage("msg", "dm", "caller"))
+
+	edits := state.UpdateFromVoiceState(&discordgo.VoiceStateUpdate{
+		VoiceState: &discordgo.VoiceState{UserID: "self", ChannelID: "dm"},
+	})
+	if len(edits) != 1 {
+		t.Fatalf("expected 1 edit, got %d", len(edits))
+	}
+	if !slices.Equal(edits[0].Call.Participants, []string{"caller", "self"}) {
+		t.Fatalf("unexpected participants after join: %v", edits[0].Call.Participants)
+	}
+
+	duplicateEdits := state.UpdateFromVoiceState(&discordgo.VoiceStateUpdate{
+		VoiceState: &discordgo.VoiceState{UserID: "self", ChannelID: "dm"},
+	})
+	if len(duplicateEdits) != 0 {
+		t.Fatalf("expected duplicate join to be ignored, got %d edits", len(duplicateEdits))
+	}
+}
+
+func TestDiscordCallStateEndedCallRemovesActiveCall(t *testing.T) {
+	state := newDiscordCallState()
+	endedAt := time.Date(2026, 6, 15, 15, 30, 0, 0, time.UTC)
+	ended := discordCallStateTestMessage("msg", "dm", "caller", "self")
+	state.UpdateFromMessage(ended)
+	ended.Call.EndedTimestamp = &endedAt
+	state.UpdateFromMessage(ended)
+
+	edits := state.UpdateFromVoiceState(&discordgo.VoiceStateUpdate{
+		VoiceState: &discordgo.VoiceState{UserID: "self", ChannelID: ""},
+	})
+	if len(edits) != 0 {
+		t.Fatalf("expected ended call to ignore voice leave, got %d edits", len(edits))
+	}
+}
+
+func TestDiscordCallStateVoiceLeaveUsesBeforeUpdateChannel(t *testing.T) {
+	state := newDiscordCallState()
+	state.UpdateFromMessage(discordCallStateTestMessage("msg", "dm", "caller", "self"))
+	delete(state.voiceChannelByUser, "self")
+
+	edits := state.UpdateFromVoiceState(&discordgo.VoiceStateUpdate{
+		VoiceState:   &discordgo.VoiceState{UserID: "self", ChannelID: ""},
+		BeforeUpdate: &discordgo.VoiceState{UserID: "self", ChannelID: "dm"},
+	})
+	if len(edits) != 1 {
+		t.Fatalf("expected 1 edit, got %d", len(edits))
+	}
+	if !slices.Equal(edits[0].Call.Participants, []string{"caller"}) {
+		t.Fatalf("unexpected participants after leave: %v", edits[0].Call.Participants)
+	}
+}
+
+func discordCallStateTestMessage(messageID, channelID string, participants ...string) *discordgo.Message {
+	return &discordgo.Message{
+		ID:        messageID,
+		ChannelID: channelID,
+		Type:      discordgo.MessageTypeCall,
+		Timestamp: time.Date(2026, 6, 15, 15, 29, 30, 0, time.UTC),
+		Author:    &discordgo.User{ID: "caller", Username: "caller"},
+		Call: &discordgo.MessageCall{
+			Participants: append([]string(nil), participants...),
+		},
+	}
+}

--- a/pkg/connector/client.go
+++ b/pkg/connector/client.go
@@ -69,6 +69,8 @@ type DiscordClient struct {
 	readStates     map[string]*discordgo.ReadState
 	readStatesLock sync.RWMutex
 
+	callState *discordCallState
+
 	relationshipLock sync.RWMutex
 	relationships    map[string]*discordgo.Relationship
 
@@ -103,6 +105,7 @@ func (d *DiscordConnector) LoadUserLogin(ctx context.Context, login *bridgev2.Us
 		userCache:     NewUserCache(session),
 		guildSettings: make(map[string]*discordgo.UserGuildSettings),
 		readStates:    make(map[string]*discordgo.ReadState),
+		callState:     newDiscordCallState(),
 		relationships: make(map[string]*discordgo.Relationship),
 	}
 	login.Client = &cl

--- a/pkg/connector/handlediscord.go
+++ b/pkg/connector/handlediscord.go
@@ -849,15 +849,18 @@ func (d *DiscordClient) handleDiscordEvent(rawEvt any) {
 			log.Err(err).Msg("Failed to persist thread info from message create")
 		}
 		d.userCache.UpdateWithMessage(evt.Message)
+		d.trackDiscordCallMessage(evt.Message)
 
 		wrappedEvt := d.wrapDiscordMessage(ctx, evt.Message, route, bridgev2.RemoteEventMessage)
 		d.UserLogin.Bridge.QueueRemoteEvent(d.UserLogin, &wrappedEvt)
 	case *discordgo.MessageUpdate:
+		fillMissingMessageUpdateFields(evt.Message, evt.BeforeUpdate)
 		ctx, log := messageCtx(ctx, evt.Message)
 		bridged, route := d.channelIsBridged(ctx, evt.ChannelID)
 		if !bridged {
 			return
 		}
+		d.trackDiscordCallMessage(evt.Message)
 
 		if err := d.upsertThreadInfoFromMessage(ctx, evt.Message); err != nil {
 			log.Err(err).Str("message_id", evt.ID).Msg("Failed to persist thread info from message update")
@@ -931,6 +934,9 @@ func (d *DiscordClient) handleDiscordEvent(rawEvt any) {
 	case *discordgo.RelationshipRemove:
 		d.handleRelationshipNickChange(ctx, evt.ID, "")
 	case *discordgo.PresenceUpdate:
+		return
+	case *discordgo.VoiceStateUpdate:
+		d.handleDiscordCallVoiceStateUpdate(ctx, evt)
 		return
 	case *discordgo.MessageAck:
 		bridged, route := d.channelIsBridged(ctx, evt.ChannelID)

--- a/pkg/connector/message_update.go
+++ b/pkg/connector/message_update.go
@@ -1,0 +1,37 @@
+// mautrix-discord - A Matrix-Discord puppeting bridge.
+// Copyright (C) 2026 Tulir Asokan
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package connector
+
+import "github.com/bwmarrin/discordgo"
+
+func fillMissingMessageUpdateFields(msg, before *discordgo.Message) {
+	if msg == nil || before == nil {
+		return
+	}
+	if msg.Author == nil {
+		msg.Author = before.Author
+	}
+	if msg.Type == discordgo.MessageTypeDefault && before.Type != discordgo.MessageTypeDefault {
+		msg.Type = before.Type
+	}
+	if msg.Timestamp.IsZero() {
+		msg.Timestamp = before.Timestamp
+	}
+	if msg.Call == nil {
+		msg.Call = before.Call
+	}
+}

--- a/pkg/connector/message_update_test.go
+++ b/pkg/connector/message_update_test.go
@@ -1,0 +1,68 @@
+// mautrix-discord - A Matrix-Discord puppeting bridge.
+// Copyright (C) 2026 Tulir Asokan
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package connector
+
+import (
+	"testing"
+	"time"
+
+	"github.com/bwmarrin/discordgo"
+)
+
+func TestFillMissingMessageUpdateFieldsPreservesCallContext(t *testing.T) {
+	started := time.Date(2026, 6, 15, 10, 0, 0, 0, time.UTC)
+	ended := started.Add(2*time.Minute + 3*time.Second)
+	before := &discordgo.Message{
+		ID:        "123",
+		ChannelID: "456",
+		Type:      discordgo.MessageTypeCall,
+		Timestamp: started,
+		Author: &discordgo.User{
+			ID:       "111",
+			Username: "caller",
+		},
+		Call: &discordgo.MessageCall{
+			Participants: []string{"111"},
+		},
+	}
+	update := &discordgo.Message{
+		ID:        "123",
+		ChannelID: "456",
+		Call: &discordgo.MessageCall{
+			Participants:   []string{"111", "222"},
+			EndedTimestamp: &ended,
+		},
+	}
+
+	fillMissingMessageUpdateFields(update, before)
+
+	if update.Author == nil || update.Author.ID != "111" {
+		t.Fatalf("Author = %#v, want caller from previous message", update.Author)
+	}
+	if update.Type != discordgo.MessageTypeCall {
+		t.Fatalf("Type = %d, want %d", update.Type, discordgo.MessageTypeCall)
+	}
+	if !update.Timestamp.Equal(started) {
+		t.Fatalf("Timestamp = %s, want %s", update.Timestamp.Format(time.RFC3339Nano), started.Format(time.RFC3339Nano))
+	}
+	if update.Call == nil {
+		t.Fatal("Call is nil")
+	}
+	if update.Call.EndedTimestamp == nil || !update.Call.EndedTimestamp.Equal(ended) {
+		t.Fatalf("Call.EndedTimestamp = %#v, want %s", update.Call.EndedTimestamp, ended.Format(time.RFC3339Nano))
+	}
+}

--- a/pkg/msgconv/call.go
+++ b/pkg/msgconv/call.go
@@ -1,0 +1,107 @@
+// mautrix-discord - A Matrix-Discord puppeting bridge.
+// Copyright (C) 2026 Tulir Asokan
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package msgconv
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/bwmarrin/discordgo"
+)
+
+type discordCallRenderOptions struct {
+	ShowActiveParticipants bool
+	CurrentUserID          string
+}
+
+func renderDiscordCallMessage(msg *discordgo.Message, options discordCallRenderOptions) string {
+	caller := "Someone"
+	if msg.Author != nil {
+		caller = msg.Author.String()
+	}
+
+	if msg.Call == nil || msg.Call.EndedTimestamp == nil {
+		if msg.Call != nil {
+			currentUserInCall := isDiscordCallParticipant(msg.Call, options.CurrentUserID)
+			if options.ShowActiveParticipants && len(msg.Call.Participants) > 0 {
+				action := "Use the Discord app to join."
+				if currentUserInCall {
+					action = "Use the Discord app to manage the call."
+				}
+				return fmt.Sprintf("(%s started a call. %s. %s)", caller, formatDiscordCallParticipantCount(len(msg.Call.Participants)), action)
+			}
+			if currentUserInCall {
+				if msg.Author != nil && msg.Author.ID != options.CurrentUserID {
+					return fmt.Sprintf("(You are in a call with %s. Use the Discord app to manage the call.)", caller)
+				}
+				return "(You are in a call. Use the Discord app to manage the call.)"
+			}
+		}
+		return fmt.Sprintf("(%s started a call. Use the Discord app to answer.)", caller)
+	}
+
+	if msg.Timestamp.IsZero() || msg.Call.EndedTimestamp.Before(msg.Timestamp) {
+		return fmt.Sprintf("(%s started a call that ended.)", caller)
+	}
+	return fmt.Sprintf("(%s started a call that lasted %s.)", caller, formatDiscordCallDuration(msg.Call.EndedTimestamp.Sub(msg.Timestamp)))
+}
+
+func isDiscordCallParticipant(call *discordgo.MessageCall, userID string) bool {
+	if userID == "" {
+		return false
+	}
+	for _, participantID := range call.Participants {
+		if participantID == userID {
+			return true
+		}
+	}
+	return false
+}
+
+func formatDiscordCallParticipantCount(count int) string {
+	if count == 1 {
+		return "1 person is in the call"
+	}
+	return fmt.Sprintf("%d people are in the call", count)
+}
+
+func formatDiscordCallDuration(duration time.Duration) string {
+	if duration < 5*time.Second {
+		return "a few seconds"
+	}
+
+	duration = duration.Round(time.Second)
+
+	hours := int(duration / time.Hour)
+	duration -= time.Duration(hours) * time.Hour
+	minutes := int(duration / time.Minute)
+	duration -= time.Duration(minutes) * time.Minute
+	seconds := int(duration / time.Second)
+
+	parts := make([]string, 0, 3)
+	if hours > 0 {
+		parts = append(parts, fmt.Sprintf("%dh", hours))
+	}
+	if minutes > 0 {
+		parts = append(parts, fmt.Sprintf("%dm", minutes))
+	}
+	if seconds > 0 || len(parts) == 0 {
+		parts = append(parts, fmt.Sprintf("%ds", seconds))
+	}
+	return strings.Join(parts, " ")
+}

--- a/pkg/msgconv/call_test.go
+++ b/pkg/msgconv/call_test.go
@@ -1,0 +1,263 @@
+// mautrix-discord - A Matrix-Discord puppeting bridge.
+// Copyright (C) 2026 Tulir Asokan
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package msgconv
+
+import (
+	"testing"
+	"time"
+
+	"github.com/bwmarrin/discordgo"
+)
+
+func TestRenderDiscordCallMessageActive(t *testing.T) {
+	msg := &discordgo.Message{
+		Type: discordgo.MessageTypeCall,
+		Author: &discordgo.User{
+			Username:      "caller",
+			Discriminator: "0",
+		},
+		Call: &discordgo.MessageCall{
+			Participants: []string{"111"},
+		},
+	}
+	want := "(caller started a call. Use the Discord app to answer.)"
+	if got := renderDiscordCallMessage(msg, discordCallRenderOptions{}); got != want {
+		t.Fatalf("renderDiscordCallMessage() = %q, want %q", got, want)
+	}
+}
+
+func TestRenderDiscordCallMessageActiveWithParticipantsInDM(t *testing.T) {
+	msg := &discordgo.Message{
+		Type: discordgo.MessageTypeCall,
+		Author: &discordgo.User{
+			Username:      "caller",
+			Discriminator: "0",
+		},
+		Call: &discordgo.MessageCall{
+			Participants: []string{"111", "222"},
+		},
+	}
+	want := "(caller started a call. Use the Discord app to answer.)"
+	if got := renderDiscordCallMessage(msg, discordCallRenderOptions{}); got != want {
+		t.Fatalf("renderDiscordCallMessage() = %q, want %q", got, want)
+	}
+}
+
+func TestRenderDiscordCallMessageActiveWithCurrentUserInDMCall(t *testing.T) {
+	msg := &discordgo.Message{
+		Type: discordgo.MessageTypeCall,
+		Author: &discordgo.User{
+			ID:            "111",
+			Username:      "caller",
+			Discriminator: "0",
+		},
+		Call: &discordgo.MessageCall{
+			Participants: []string{"111", "222"},
+		},
+	}
+	options := discordCallRenderOptions{CurrentUserID: "222"}
+	want := "(You are in a call with caller. Use the Discord app to manage the call.)"
+	if got := renderDiscordCallMessage(msg, options); got != want {
+		t.Fatalf("renderDiscordCallMessage() = %q, want %q", got, want)
+	}
+}
+
+func TestRenderDiscordCallMessageActiveWithoutCurrentUserInDMCall(t *testing.T) {
+	msg := &discordgo.Message{
+		Type: discordgo.MessageTypeCall,
+		Author: &discordgo.User{
+			ID:            "111",
+			Username:      "caller",
+			Discriminator: "0",
+		},
+		Call: &discordgo.MessageCall{
+			Participants: []string{"111"},
+		},
+	}
+	options := discordCallRenderOptions{CurrentUserID: "222"}
+	want := "(caller started a call. Use the Discord app to answer.)"
+	if got := renderDiscordCallMessage(msg, options); got != want {
+		t.Fatalf("renderDiscordCallMessage() = %q, want %q", got, want)
+	}
+}
+
+func TestRenderDiscordCallMessageActiveWithParticipantsInGroupDM(t *testing.T) {
+	msg := &discordgo.Message{
+		Type: discordgo.MessageTypeCall,
+		Author: &discordgo.User{
+			ID:            "111",
+			Username:      "caller",
+			Discriminator: "0",
+		},
+		Call: &discordgo.MessageCall{
+			Participants: []string{"111", "222"},
+		},
+	}
+	options := discordCallRenderOptions{ShowActiveParticipants: true, CurrentUserID: "333"}
+	want := "(caller started a call. 2 people are in the call. Use the Discord app to join.)"
+	if got := renderDiscordCallMessage(msg, options); got != want {
+		t.Fatalf("renderDiscordCallMessage() = %q, want %q", got, want)
+	}
+}
+
+func TestRenderDiscordCallMessageActiveWithCurrentUserInGroupDM(t *testing.T) {
+	msg := &discordgo.Message{
+		Type: discordgo.MessageTypeCall,
+		Author: &discordgo.User{
+			ID:            "111",
+			Username:      "caller",
+			Discriminator: "0",
+		},
+		Call: &discordgo.MessageCall{
+			Participants: []string{"111", "222"},
+		},
+	}
+	options := discordCallRenderOptions{ShowActiveParticipants: true, CurrentUserID: "222"}
+	want := "(caller started a call. 2 people are in the call. Use the Discord app to manage the call.)"
+	if got := renderDiscordCallMessage(msg, options); got != want {
+		t.Fatalf("renderDiscordCallMessage() = %q, want %q", got, want)
+	}
+}
+
+func TestRenderDiscordCallMessageActiveWithOneParticipantInGroupDM(t *testing.T) {
+	msg := &discordgo.Message{
+		Type: discordgo.MessageTypeCall,
+		Author: &discordgo.User{
+			ID:            "111",
+			Username:      "caller",
+			Discriminator: "0",
+		},
+		Call: &discordgo.MessageCall{
+			Participants: []string{"111"},
+		},
+	}
+	options := discordCallRenderOptions{ShowActiveParticipants: true, CurrentUserID: "222"}
+	want := "(caller started a call. 1 person is in the call. Use the Discord app to join.)"
+	if got := renderDiscordCallMessage(msg, options); got != want {
+		t.Fatalf("renderDiscordCallMessage() = %q, want %q", got, want)
+	}
+}
+
+func TestRenderDiscordCallMessageEnded(t *testing.T) {
+	started := time.Date(2026, 6, 15, 10, 0, 0, 0, time.UTC)
+	ended := started.Add(2*time.Minute + 3*time.Second)
+	msg := &discordgo.Message{
+		Type:      discordgo.MessageTypeCall,
+		Timestamp: started,
+		Author: &discordgo.User{
+			Username:      "caller",
+			Discriminator: "0",
+		},
+		Call: &discordgo.MessageCall{
+			Participants:   []string{"111", "222"},
+			EndedTimestamp: &ended,
+		},
+	}
+	want := "(caller started a call that lasted 2m 3s.)"
+	if got := renderDiscordCallMessage(msg, discordCallRenderOptions{}); got != want {
+		t.Fatalf("renderDiscordCallMessage() = %q, want %q", got, want)
+	}
+}
+
+func TestRenderDiscordCallMessageEndedImmediately(t *testing.T) {
+	started := time.Date(2026, 6, 15, 10, 0, 0, 0, time.UTC)
+	msg := &discordgo.Message{
+		Type:      discordgo.MessageTypeCall,
+		Timestamp: started,
+		Author: &discordgo.User{
+			Username:      "caller",
+			Discriminator: "0",
+		},
+		Call: &discordgo.MessageCall{
+			Participants:   []string{"111"},
+			EndedTimestamp: &started,
+		},
+	}
+	want := "(caller started a call that lasted a few seconds.)"
+	if got := renderDiscordCallMessage(msg, discordCallRenderOptions{}); got != want {
+		t.Fatalf("renderDiscordCallMessage() = %q, want %q", got, want)
+	}
+}
+
+func TestRenderDiscordCallMessageEndedBeforeStartTime(t *testing.T) {
+	started := time.Date(2026, 6, 15, 10, 0, 0, 0, time.UTC)
+	ended := started.Add(-time.Second)
+	msg := &discordgo.Message{
+		Type:      discordgo.MessageTypeCall,
+		Timestamp: started,
+		Author: &discordgo.User{
+			Username:      "caller",
+			Discriminator: "0",
+		},
+		Call: &discordgo.MessageCall{
+			Participants:   []string{"111"},
+			EndedTimestamp: &ended,
+		},
+	}
+	want := "(caller started a call that ended.)"
+	if got := renderDiscordCallMessage(msg, discordCallRenderOptions{}); got != want {
+		t.Fatalf("renderDiscordCallMessage() = %q, want %q", got, want)
+	}
+}
+
+func TestRenderDiscordCallMessageEndedWithoutStartTime(t *testing.T) {
+	ended := time.Date(2026, 6, 15, 10, 2, 3, 0, time.UTC)
+	msg := &discordgo.Message{
+		Type: discordgo.MessageTypeCall,
+		Author: &discordgo.User{
+			Username:      "caller",
+			Discriminator: "0",
+		},
+		Call: &discordgo.MessageCall{
+			Participants:   []string{"111"},
+			EndedTimestamp: &ended,
+		},
+	}
+	want := "(caller started a call that ended.)"
+	if got := renderDiscordCallMessage(msg, discordCallRenderOptions{}); got != want {
+		t.Fatalf("renderDiscordCallMessage() = %q, want %q", got, want)
+	}
+}
+
+func TestFormatDiscordCallDuration(t *testing.T) {
+	tests := map[string]struct {
+		duration time.Duration
+		want     string
+	}{
+		"zero":             {duration: 0, want: "a few seconds"},
+		"very short":       {duration: 4*time.Second + 999*time.Millisecond, want: "a few seconds"},
+		"short threshold":  {duration: 5 * time.Second, want: "5s"},
+		"rounds down":      {duration: 9*time.Second + 400*time.Millisecond, want: "9s"},
+		"rounds up":        {duration: 8*time.Second + 600*time.Millisecond, want: "9s"},
+		"exact minute":     {duration: time.Minute, want: "1m"},
+		"minute seconds":   {duration: 2*time.Minute + 3*time.Second, want: "2m 3s"},
+		"exact hour":       {duration: time.Hour, want: "1h"},
+		"hour minute":      {duration: time.Hour + 2*time.Minute, want: "1h 2m"},
+		"hour minute sec":  {duration: time.Hour + 2*time.Minute + 3*time.Second, want: "1h 2m 3s"},
+		"minute carry":     {duration: 59*time.Second + 600*time.Millisecond, want: "1m"},
+		"hour carry":       {duration: 59*time.Minute + 59*time.Second + 600*time.Millisecond, want: "1h"},
+		"negative guarded": {duration: -time.Second, want: "a few seconds"},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			if got := formatDiscordCallDuration(test.duration); got != test.want {
+				t.Fatalf("formatDiscordCallDuration(%s) = %q, want %q", test.duration, got, test.want)
+			}
+		})
+	}
+}

--- a/pkg/msgconv/from-discord.go
+++ b/pkg/msgconv/from-discord.go
@@ -31,6 +31,7 @@ import (
 	"go.mau.fi/util/exmaps"
 	"go.mau.fi/util/ptr"
 	"maunium.net/go/mautrix/bridgev2"
+	"maunium.net/go/mautrix/bridgev2/database"
 	"maunium.net/go/mautrix/bridgev2/networkid"
 	"maunium.net/go/mautrix/event"
 	"maunium.net/go/mautrix/format"
@@ -137,16 +138,20 @@ func (mc *MessageConverter) ToMatrix(
 	// 	puppet.addMemberMeta(part, msg)
 	// }
 
-	sender := discordid.MakeUserID(msg.Author.ID)
-	var pmp event.BeeperPerMessageProfile
-	ghost, err := portal.Bridge.GetGhostByID(ctx, sender)
-	if err != nil {
-		log.Err(err).Msg("Failed to get ghost for per-message profile")
-	} else {
-		pmp.ID = string(ghost.Intent.GetMXID())
-		pmp.Displayname = ghost.Name
-		if ghost.AvatarMXC != "" {
-			pmp.AvatarURL = &ghost.AvatarMXC
+	var pmp *event.BeeperPerMessageProfile
+	if msg.Author != nil {
+		sender := discordid.MakeUserID(msg.Author.ID)
+		pmpVal := event.BeeperPerMessageProfile{}
+		ghost, err := portal.Bridge.GetGhostByID(ctx, sender)
+		if err != nil {
+			log.Err(err).Msg("Failed to get ghost for per-message profile")
+		} else {
+			pmpVal.ID = string(ghost.Intent.GetMXID())
+			pmpVal.Displayname = ghost.Name
+			if ghost.AvatarMXC != "" {
+				pmpVal.AvatarURL = &ghost.AvatarMXC
+			}
+			pmp = &pmpVal
 		}
 	}
 
@@ -158,7 +163,9 @@ func (mc *MessageConverter) ToMatrix(
 		// more messages). Adding per-message profiles to every part helps them
 		// present the right message authorship information even when a
 		// membership event isn't present.
-		part.Content.BeeperPerMessageProfile = &pmp
+		if pmp != nil {
+			part.Content.BeeperPerMessageProfile = pmp
+		}
 	}
 
 	converted := &bridgev2.ConvertedMessage{Parts: parts}
@@ -239,10 +246,13 @@ func (mc *MessageConverter) renderDiscordTextMessage(ctx context.Context, intent
 	log := zerolog.Ctx(ctx)
 	switch msg.Type {
 	case discordgo.MessageTypeCall:
+		callOptions := discordCallRenderOptions{
+			ShowActiveParticipants: portal.RoomType == database.RoomTypeGroupDM,
+			CurrentUserID:          discordid.ParseUserLoginID(source.ID),
+		}
 		return &bridgev2.ConvertedMessagePart{Type: event.EventMessage, Content: &event.MessageEventContent{
 			MsgType: event.MsgEmote,
-			// TODO: Use ghost name instead?
-			Body: fmt.Sprintf("(%s started a call. Use the Discord app to answer.)", msg.Author.String()),
+			Body:    renderDiscordCallMessage(msg, callOptions),
 		}}
 	case discordgo.MessageTypeGuildMemberJoin:
 		// This is only used for backfilled user join notices (e.g. "Good to


### PR DESCRIPTION
## Depends on

- https://github.com/beeper/discordgo/pull/7

This uses `discordgo.Message.Call`, so the bridge PR should stay draft until the dependency lands and the module can be bumped normally.

## Summary

Keeps Discord private call notices up to date using call message metadata and voice state events.

## Changes

- render active call notices from `message.call.participants`
- render ended call notices from `message.call.ended_timestamp`, including short human-readable durations
- preserve call context across partial `MESSAGE_UPDATE` payloads
- track active private calls in memory and edit the Matrix notice on `VOICE_STATE_UPDATE` join/leave events
- keep 1:1 DM notices focused on whether the current user is in the call, while group DMs show participant counts

## Expected behavior

1:1 DMs:

- incoming active call while not joined: `(caller started a call. Use the Discord app to answer.)`
- current user joins: `(You are in a call with caller. Use the Discord app to manage the call.)`
- current user leaves before the call ends: the notice edits back to the incoming active call text
- call ends: `(caller started a call that lasted 9s.)`

Group DMs:

- active call with two participants, current user not joined: `(caller started a call. 2 people are in the call. Use the Discord app to join.)`
- current user joins: `(caller started a call. 3 people are in the call. Use the Discord app to manage the call.)`
- participants join/leave: the participant count updates from voice state events
- call ends: `(caller started a call that lasted 2m 3s.)`

## Testing

- `go test ./pkg/msgconv ./pkg/connector -run 'TestRenderDiscordCallMessage|TestFormatDiscordCallDuration|TestFillMissingMessageUpdateFieldsPreservesCallContext|TestDiscordCallState' -count=1`
- `go test ./... -run '^$'`
- `pre-commit run --all-files`
- Manual Beeper smoke test with a local bridge: 1:1 call start/join/leave/end edits the notice as expected