### PR TITLE
Keep Discord upload content type

### DIFF
--- a/attachments.go
+++ b/attachments.go
@@ -65,7 +65,7 @@ func downloadDiscordAttachment(cli *http.Client, url string, maxSize int64) ([]b
 	}
 }
 
-func uploadDiscordAttachment(cli *http.Client, url string, data []byte) error {
+func uploadDiscordAttachment(cli *http.Client, url string, data []byte, contentType string) error {
 	req, err := http.NewRequest(http.MethodPut, url, bytes.NewReader(data))
 	if err != nil {
 		return err
@@ -73,7 +73,10 @@ func uploadDiscordAttachment(cli *http.Client, url string, data []byte) error {
 	for key, value := range discordgo.DroidBaseHeaders {
 		req.Header.Set(key, value)
 	}
-	req.Header.Set("Content-Type", "application/octet-stream")
+	if contentType == "" {
+		contentType = "application/octet-stream"
+	}
+	req.Header.Set("Content-Type", contentType)
 	req.Header.Set("Referer", "https://discord.com/")
 	req.Header.Set("Sec-Fetch-Dest", "empty")
 	req.Header.Set("Sec-Fetch-Mode", "cors")

--- a/portal.go
+++ b/portal.go
@@ -1698,7 +1698,7 @@ func (portal *Portal) handleMatrixMessage(sender *User, evt *event.Event) {
 			}
 			prepared := prep.Attachments[0]
 			att.UploadedFilename = prepared.UploadFilename
-			err = uploadDiscordAttachment(sender.Session.Client, prepared.UploadURL, data)
+			err = uploadDiscordAttachment(sender.Session.Client, prepared.UploadURL, data, att.OriginalContentType)
 			if err != nil {
 				go portal.sendMessageMetrics(evt, err, "Error reuploading media in")
 				return


### PR DESCRIPTION
## Summary

Use the Matrix attachment MIME type when uploading prepared Discord CDN attachments instead of always sending `application/octet-stream`.

## Root Cause

The Discord CDN prepare request already includes `OriginalContentType`, but the subsequent PUT upload hardcodes `Content-Type: application/octet-stream`. Discord voice messages require the uploaded attachment to be treated as audio, so the upload content type needs to match the prepared attachment metadata.

## Change

- Let `uploadDiscordAttachment` accept a content type and fall back to `application/octet-stream` only when none is known.
- Pass the prepared attachment `OriginalContentType` from the Matrix message send path.