### PR TITLE
msgconv: preserve Discord voice content type

### DIFF
--- a/pkg/msgconv/from-matrix.go
+++ b/pkg/msgconv/from-matrix.go
@@ -158,11 +158,13 @@ func (mc *MessageConverter) ToDiscord(
 			ID:       "0",
 			Filename: filename,
 		}
+		if content.Info != nil {
+			att.OriginalContentType = content.Info.MimeType
+		}
 		if voiceMeta != nil {
 			flags := int(discordgo.MessageFlagsIsVoiceMessage)
 			req.Flags = &flags
 			att.ContentType = voiceMeta.ContentType
-			att.OriginalContentType = voiceMeta.ContentType
 			att.DurationSeconds = voiceMeta.DurationSeconds
 			att.Waveform = voiceMeta.Waveform
 		}

--- a/pkg/msgconv/from-matrix.go
+++ b/pkg/msgconv/from-matrix.go
@@ -55,7 +55,7 @@ func parseAllowedLinkPreviews(raw map[string]any) []string {
 	return allowedLinkPreviews
 }
 
-func uploadDiscordAttachment(cli *http.Client, url string, data []byte, contentType string) error {
+func uploadDiscordAttachment(cli *http.Client, url string, data []byte) error {
 	req, err := http.NewRequest(http.MethodPut, url, bytes.NewReader(data))
 	if err != nil {
 		return err
@@ -64,10 +64,7 @@ func uploadDiscordAttachment(cli *http.Client, url string, data []byte, contentT
 	for key, value := range discordgo.DroidBaseHeaders {
 		req.Header.Set(key, value)
 	}
-	if contentType == "" {
-		contentType = "application/octet-stream"
-	}
-	req.Header.Set("Content-Type", contentType)
+	req.Header.Set("Content-Type", "application/octet-stream")
 	req.Header.Set("Referer", "https://discord.com/")
 	req.Header.Set("Sec-Fetch-Dest", "empty")
 	req.Header.Set("Sec-Fetch-Mode", "cors")
@@ -165,6 +162,7 @@ func (mc *MessageConverter) ToDiscord(
 			flags := int(discordgo.MessageFlagsIsVoiceMessage)
 			req.Flags = &flags
 			att.ContentType = voiceMeta.ContentType
+			att.OriginalContentType = voiceMeta.ContentType
 			att.DurationSeconds = voiceMeta.DurationSeconds
 			att.Waveform = voiceMeta.Waveform
 		}
@@ -172,9 +170,10 @@ func (mc *MessageConverter) ToDiscord(
 		uploadID := mc.NextDiscordUploadID()
 		log.Debug().Str("upload_id", uploadID).Msg("Preparing attachment")
 		filePrep := &discordgo.FilePrepare{
-			Size: len(mediaData),
-			Name: att.Filename,
-			ID:   uploadID,
+			Size:                len(mediaData),
+			Name:                att.Filename,
+			ID:                  uploadID,
+			OriginalContentType: att.OriginalContentType,
 		}
 		prep, err := session.ChannelAttachmentCreate(channelID, &discordgo.ReqPrepareAttachments{
 			Files: []*discordgo.FilePrepare{filePrep},
@@ -188,7 +187,7 @@ func (mc *MessageConverter) ToDiscord(
 		prepared := prep.Attachments[0]
 		att.UploadedFilename = prepared.UploadFilename
 
-		err = uploadDiscordAttachment(session.Client, prepared.UploadURL, mediaData, att.OriginalContentType)
+		err = uploadDiscordAttachment(session.Client, prepared.UploadURL, mediaData)
 		if err != nil {
 			log.Err(err).Msg("Failed to reupload Discord attachment after preparing")
 			return nil, bridgev2.ErrMediaReuploadFailed

--- a/pkg/msgconv/from-matrix.go
+++ b/pkg/msgconv/from-matrix.go
@@ -64,6 +64,8 @@ func uploadDiscordAttachment(cli *http.Client, url string, data []byte) error {
 	for key, value := range discordgo.DroidBaseHeaders {
 		req.Header.Set(key, value)
 	}
+	// The first-party web client does not set a content type, so we shouldn't
+	// either.
 	req.Header.Set("Content-Type", "application/octet-stream")
 	req.Header.Set("Referer", "https://discord.com/")
 	req.Header.Set("Sec-Fetch-Dest", "empty")


### PR DESCRIPTION
## Summary

Preserve the validated audio MIME type in Discord attachment prepare and final message metadata for Matrix voice messages.

## Root Cause

The megadiscord send path validates Matrix voice metadata and sets the voice flag, final attachment content type, duration, and waveform, but never sets `OriginalContentType` before Discord attachment prepare. That leaves the prepare request and final message attachment without the audio MIME type Discord expects for voice messages.

## Change

- Set `OriginalContentType` from the validated voice MIME type.
- Pass `OriginalContentType` in `FilePrepare`.
- Keep the CDN PUT upload on `application/octet-stream`, matching Discord web behavior.