### PR TITLE
backfill: retry failed history fetches

### DIFF
--- a/pkg/connector/backfill.go
+++ b/pkg/connector/backfill.go
@@ -18,8 +18,11 @@ package connector
 
 import (
 	"context"
+	"errors"
+	"net/http"
 	"slices"
 	"strconv"
+	"time"
 
 	"github.com/bwmarrin/discordgo"
 	"github.com/rs/zerolog"
@@ -89,7 +92,9 @@ func (d *DiscordClient) FetchMessages(ctx context.Context, fetchParams bridgev2.
 	// ChannelMessages returns messages ordered from newest to oldest.
 	count := min(fetchParams.Count, 100)
 	log.Debug().Msg("Fetching channel history for backfill")
-	msgs, err := d.Session.ChannelMessages(channelID, count, beforeID, afterID, "", refererOpt)
+	msgs, err := d.retryHistoryFetch(ctx, func() ([]*discordgo.Message, error) {
+		return d.Session.ChannelMessages(channelID, count, beforeID, afterID, "", refererOpt)
+	})
 	if err != nil {
 		return nil, d.tryWrappingError(ctx, err)
 	}
@@ -207,6 +212,49 @@ func (d *DiscordClient) FetchMessages(ctx context.Context, fetchParams bridgev2.
 		// of `count`, but that's probably okay.
 		HasMore: len(msgs) == count,
 	}, nil
+}
+
+// retryHistoryFetch retries fetch while the error looks transient.
+//
+// discordgo parses the body of a 429 before honouring Retry-After and returns
+// early if that parse fails, and Discord's edge answers some rate limits with
+// an HTML block page. The fetch then fails without ever being retried.
+func (d *DiscordClient) retryHistoryFetch(
+	ctx context.Context, fetch func() ([]*discordgo.Message, error),
+) ([]*discordgo.Message, error) {
+	interval := time.Duration(d.connector.Config.BackfillRetryIntervalSeconds) * time.Second
+	for attempt := 0; ; attempt++ {
+		msgs, err := fetch()
+		if err == nil || attempt >= d.connector.Config.BackfillRetries || !shouldRetryHistoryFetch(err) {
+			return msgs, err
+		}
+		zerolog.Ctx(ctx).Warn().Err(err).Int("attempt", attempt+1).
+			Msg("Failed to fetch channel history for backfill, retrying")
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(interval):
+		}
+	}
+}
+
+// shouldRetryHistoryFetch reports whether a failed fetch is worth another
+// attempt.
+func shouldRetryHistoryFetch(err error) bool {
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+	// A response that arrived but would not decode. Deterministic, unlike the
+	// unparseable rate limit body, which discordgo returns unwrapped.
+	if errors.Is(err, discordgo.ErrJSONUnmarshal) {
+		return false
+	}
+	var restErr *discordgo.RESTError
+	if errors.As(err, &restErr) && restErr.Response != nil {
+		return restErr.Response.StatusCode == http.StatusTooManyRequests ||
+			restErr.Response.StatusCode >= 500
+	}
+	return true
 }
 
 func (d *DiscordClient) GetBackfillMaxBatchCount(

--- a/pkg/connector/backfill_test.go
+++ b/pkg/connector/backfill_test.go
@@ -1,0 +1,35 @@
+package connector
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/bwmarrin/discordgo"
+)
+
+func TestShouldRetryHistoryFetch(t *testing.T) {
+	restError := func(status int) error {
+		return &discordgo.RESTError{Response: &http.Response{StatusCode: status}}
+	}
+	for _, test := range []struct {
+		name string
+		err  error
+		want bool
+	}{
+		// The rate limit discordgo fails to parse and therefore never retries.
+		{"unparseable rate limit body", &json.SyntaxError{}, true},
+		{"server error", restError(http.StatusInternalServerError), true},
+		{"too many requests", restError(http.StatusTooManyRequests), true},
+		// A response that arrived and would not decode is deterministic.
+		{"undecodable response", fmt.Errorf("%w: unknown component type: 16", discordgo.ErrJSONUnmarshal), false},
+		{"forbidden", restError(http.StatusForbidden), false},
+		{"cancelled", context.Canceled, false},
+	} {
+		if got := shouldRetryHistoryFetch(test.err); got != test.want {
+			t.Errorf("%s: got %v, want %v", test.name, got, test.want)
+		}
+	}
+}

--- a/pkg/connector/config.go
+++ b/pkg/connector/config.go
@@ -48,6 +48,12 @@ type Config struct {
 
 	LogWhenDroppingMessages bool `yaml:"log_when_dropping_messages"`
 
+	// BackfillRetries is how many times a failed history fetch is retried before
+	// the backfill is abandoned. 0 disables retrying.
+	BackfillRetries int `yaml:"backfill_retries"`
+	// BackfillRetryIntervalSeconds is how long to wait between those retries.
+	BackfillRetryIntervalSeconds int `yaml:"backfill_retry_interval_seconds"`
+
 	// Proxy is a static proxy address (HTTP or SOCKS5) for connecting to
 	// Discord. Ignored when GetProxyFrom is set.
 	Proxy string `yaml:"proxy"`
@@ -142,6 +148,8 @@ func upgradeConfig(helper up.Helper) {
 	helper.Copy(up.Bool, "custom_emoji_reactions")
 	helper.Copy(up.Bool, "per_message_profiles_on_every_message_hack")
 	helper.Copy(up.Bool, "log_when_dropping_messages")
+	helper.Copy(up.Int, "backfill_retries")
+	helper.Copy(up.Int, "backfill_retry_interval_seconds")
 	helper.Copy(up.Str, "proxy")
 	helper.Copy(up.Str, "get_proxy_from")
 	helper.Copy(up.Bool, "proxy_media")

--- a/pkg/connector/example-config.yaml
+++ b/pkg/connector/example-config.yaml
@@ -78,3 +78,13 @@ proxy_login_remoteauth: true
 # message content, or attachment data are never incorporated into the reported
 # information.
 report_scrubbed_account_standing: false
+
+# Retrying a failed history fetch during backfill. Discord sometimes answers a
+# rate limit with an HTML block page instead of JSON, which discordgo cannot
+# parse and does not retry, aborting the backfill. Initial backfill only runs
+# once, so the room keeps whatever history it got.
+#
+# Only rate limits, server errors and transport failures are retried. Set
+# retries to 0 to disable.
+backfill_retries: 5
+backfill_retry_interval_seconds: 30


### PR DESCRIPTION
Discord sometimes answers with http errors and html instead of json, this currently causes incomplete backfills.
This change implements a retry mechanism for backfilling.

Only errors that might resolve are retried: rate limits, 5xx and transport failures. A 4xx that is not a rate limit is a definitive answer, and a response that arrived but failed to decode is deterministic, so both fail immediately rather than spending the whole retry budget to reach the same result.

Adds `backfill_retries` and `backfill_retry_interval_seconds`. The wait is context-aware so it doesn't hold up shutdown. Pacing between batches is left alone; the backfill queue's `batch_delay` already covers that.

### Checklist

* [x] I have read and followed the contributing guidelines at <https://docs.mau.fi/bridges/general/contributing.html>
