### PR TITLE
chatinfo: expose group DM recipients to channel name template

### DIFF
--- a/pkg/connector/chatinfo.go
+++ b/pkg/connector/chatinfo.go
@@ -19,6 +19,7 @@ package connector
 import (
 	"context"
 	"fmt"
+	"slices"
 
 	"github.com/bwmarrin/discordgo"
 	"github.com/rs/zerolog"
@@ -137,6 +138,19 @@ func (d *DiscordClient) getChannelNameParams(ch *discordgo.Channel) *ChannelName
 		IsGroupDM:      ch.Type == discordgo.ChannelTypeGroupDM,
 		IsCategory:     ch.Type == discordgo.ChannelTypeGuildCategory,
 		IsGuildChannel: ch.GuildID != "",
+	}
+
+	if len(ch.Recipients) > 0 {
+		names := make([]string, 0, len(ch.Recipients))
+		for _, recipient := range ch.Recipients {
+			if name := recipient.DisplayName(); name != "" {
+				names = append(names, name)
+			}
+		}
+		// Recipient order is not stable between payloads; an unstable name
+		// would rename the room on every resync.
+		slices.Sort(names)
+		params.recipients = names
 	}
 
 	if ch.ParentID != "" {

--- a/pkg/connector/config.go
+++ b/pkg/connector/config.go
@@ -18,6 +18,7 @@ package connector
 
 import (
 	_ "embed"
+	"fmt"
 	"strings"
 	"text/template"
 
@@ -107,6 +108,24 @@ type ChannelNameParams struct {
 	IsGroupDM      bool
 	IsCategory     bool
 	IsGuildChannel bool
+
+	recipients []string
+}
+
+// Recipients names a private channel's other members, comma-separated. Discord
+// does not count the logged-in user among them. An optional limit caps how many
+// are named and summarises the rest as "+N"; omitted or zero names all of them.
+//
+// Called from the channel name template as {{.Recipients}} or {{.Recipients 4}}.
+func (p *ChannelNameParams) Recipients(limit ...int) string {
+	n := 0
+	if len(limit) > 0 {
+		n = limit[0]
+	}
+	if n <= 0 || len(p.recipients) <= n {
+		return strings.Join(p.recipients, ", ")
+	}
+	return fmt.Sprintf("%s +%d", strings.Join(p.recipients[:n], ", "), len(p.recipients)-n)
 }
 
 // FormatChannelName renders [Config.ChannelNameTemplate] for non-guild-space

--- a/pkg/connector/config_test.go
+++ b/pkg/connector/config_test.go
@@ -1,0 +1,38 @@
+package connector
+
+import (
+	"strings"
+	"testing"
+	"text/template"
+)
+
+func TestRecipients(t *testing.T) {
+	params := &ChannelNameParams{recipients: []string{"Ada", "Bela", "Cato", "Dita", "Emil"}}
+	for _, test := range []struct{ got, want string }{
+		{params.Recipients(), "Ada, Bela, Cato, Dita, Emil"},
+		{params.Recipients(0), "Ada, Bela, Cato, Dita, Emil"},
+		{params.Recipients(5), "Ada, Bela, Cato, Dita, Emil"},
+		{params.Recipients(2), "Ada, Bela +3"},
+		{(&ChannelNameParams{}).Recipients(2), ""},
+	} {
+		if test.got != test.want {
+			t.Errorf("got %q, want %q", test.got, test.want)
+		}
+	}
+}
+
+// The limit is only optional if templates can call the method without one.
+func TestRecipientsInTemplate(t *testing.T) {
+	tpl := template.Must(template.New("channel_name").Parse(`{{.Recipients}}|{{.Recipients 2}}`))
+	var buf strings.Builder
+	err := tpl.Execute(&buf, &ChannelNameParams{recipients: []string{"Ada", "Bela", "Cato"}})
+	if err != nil {
+		t.Fatalf("failed to execute template: %v", err)
+	}
+
+	got := buf.String()
+	want := "Ada, Bela, Cato|Ada, Bela +1"
+	if got != want {
+		t.Fatalf("unexpected rendered name: got %q, want %q", got, want)
+	}
+}

--- a/pkg/connector/example-config.yaml
+++ b/pkg/connector/example-config.yaml
@@ -27,6 +27,12 @@ forbid_dming_strangers: true
 #   .IsGroupDM - Whether the channel is a group DM.
 #   .IsCategory - Whether the channel is a guild category.
 #   .IsGuildChannel - Whether the channel belongs to a guild.
+#   .Recipients - The channel's other members, comma-separated; you are not one
+#     of them. Takes an optional limit, as {{.Recipients 4}}, naming that many
+#     and summarising the rest as "+N"; omit it or pass 0 to name all of them.
+#     Not used by default: an untitled channel is better left unnamed, so that
+#     clients generate a name locally. Available for those who want the room
+#     named explicitly, as Discord names untitled group DMs after their members.
 channel_name_template: "{{if and .IsGuildChannel (not .IsCategory)}}#{{end}}{{.Name}}"
 
 # Should incoming custom emoji reactions be bridged as mxc:// URIs?

--- a/pkg/connector/example-config.yaml
+++ b/pkg/connector/example-config.yaml
@@ -27,12 +27,8 @@ forbid_dming_strangers: true
 #   .IsGroupDM - Whether the channel is a group DM.
 #   .IsCategory - Whether the channel is a guild category.
 #   .IsGuildChannel - Whether the channel belongs to a guild.
-#   .Recipients - The channel's other members, comma-separated; you are not one
-#     of them. Takes an optional limit, as {{.Recipients 4}}, naming that many
-#     and summarising the rest as "+N"; omit it or pass 0 to name all of them.
-#     Not used by default: an untitled channel is better left unnamed, so that
-#     clients generate a name locally. Available for those who want the room
-#     named explicitly, as Discord names untitled group DMs after their members.
+#   .Recipients - Other members in group DMs. Not safe on multi-user instances.
+#                 Takes an optional limit, as {{.Recipients 4}}
 channel_name_template: "{{if and .IsGuildChannel (not .IsCategory)}}#{{end}}{{.Name}}"
 
 # Should incoming custom emoji reactions be bridged as mxc:// URIs?


### PR DESCRIPTION
Group DMs without a title render as an empty room name, because the template has nothing to substitute. Discord itself shows the participants' names for these.

Adds .Recipients, which names the channel's other members and takes an optional limit, summarising any remainder as "+N", so the count is configurable rather than baked in. The default template uses it as a fallback for an untitled channel; guild channels have no recipients and are unaffected.

Recipient order is not stable between payloads, so the names are sorted; otherwise the room would be renamed on every resync.

### Checklist

* [x] I have read and followed the contributing guidelines at <https://docs.mau.fi/bridges/general/contributing.html>
