### PR TITLE
Render thumbnail-only rich embeds

### DIFF
--- a/portal_convert.go
+++ b/portal_convert.go
@@ -508,6 +508,13 @@ func (portal *Portal) convertDiscordRichEmbed(ctx context.Context, intent *appse
 		} else {
 			htmlParts = append(htmlParts, fmt.Sprintf(embedHTMLImage, dbFile.MXC))
 		}
+	} else if embed.Thumbnail != nil {
+		dbFile, err := portal.bridge.copyAttachmentToMatrix(intent, embed.Thumbnail.ProxyURL, false, NoMeta)
+		if err != nil {
+			log.Warn().Err(err).Msg("Failed to reupload thumbnail in embed")
+		} else {
+			htmlParts = append(htmlParts, fmt.Sprintf(embedHTMLImage, dbFile.MXC))
+		}
 	}
 	var embedDateHTML string
 	if embed.Timestamp != "" {


### PR DESCRIPTION
Rich embeds that carry a Thumbnail but no full Image currently render no image at all. This shows up on link-preview/article-style bot embeds: the text bridges fine but the thumbnail gets dropped.

convertDiscordRichEmbed only handled embed.Image. This adds an else-if fallback that reuploads embed.Thumbnail through the same copyAttachmentToMatrix + embedHTMLImage path, so a thumbnail-only embed gets its image. It mirrors what convertDiscordLinkEmbedToBeeper already does (it falls back to embed.Thumbnail when embed.Image is nil), just for the rich-embed path.

Small change, ~8 lines. Builds clean with CGO against v0.7.7.

I asked about this in #discord:maunium.net and you mentioned the legacy bridge probably won't take minor changes, and that the same fix might belong in the new bridge if the issue exists there (unless it's already bridged as a url preview). Sending this against the legacy path anyway in case it's useful for anyone still running it, but no worries if you'd rather it land in the rewrite. Happy to redo it there instead.